### PR TITLE
Improve test performance in Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,4 +24,4 @@ test:
   pre:
     - yarn run build
   override:
-    - yarn test
+    - yarn run test-ci

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev": "sharetribe-scripts start",
     "build": "sharetribe-scripts build",
     "test": "sharetribe-scripts test --env=jsdom",
+    "test-ci": "sharetribe-scripts test --env=jsdom --runInBand",
     "eject": "sharetribe-scripts eject",
     "start": "node server/index.js",
     "dev-server": "npm run build&&nodemon --watch server server/index.js"


### PR DESCRIPTION
Jest has some performance problems in Circle CI. This PR tries to fix those by using the [--runInBand](https://github.com/facebook/jest/blob/12c13459b35c812db7eee6663bf521032316c127/src/cli/processArgs.js#L70) flag based on the answer to http://stackoverflow.com/questions/36747251/error-running-jest-on-circleci-npm-test-died-unexpectedly

**--runInBand**:

> Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare.