### PR TITLE
Styleguide

### DIFF
--- a/src/components/Hello/Hello.example.js
+++ b/src/components/Hello/Hello.example.js
@@ -1,0 +1,13 @@
+import Hello from './Hello';
+
+export const HelloWorld = {
+  component: Hello,
+  description: 'Hello to world',
+  props: { name: 'world' },
+};
+
+export const HelloMars = {
+  component: Hello,
+  description: 'Hello to mars',
+  props: { name: 'mars' },
+};

--- a/src/components/Hello/Hello.js
+++ b/src/components/Hello/Hello.js
@@ -1,0 +1,9 @@
+import React, { PropTypes } from 'react';
+
+const Hello = ({ name }) => <p>hello, {name}!</p>;
+
+const { string } = PropTypes;
+
+Hello.propTypes = { name: string.isRequired };
+
+export default Hello;

--- a/src/components/examples.js
+++ b/src/components/examples.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export*/
+import * as Hello from './Hello/Hello.example';
+
+export { Hello };

--- a/src/containers/StyleguidePage/StyleguidePage.css
+++ b/src/containers/StyleguidePage/StyleguidePage.css
@@ -1,0 +1,6 @@
+.root {
+  & ul {
+    list-style: none;
+    padding: 0;
+  }
+}

--- a/src/containers/StyleguidePage/StyleguidePage.js
+++ b/src/containers/StyleguidePage/StyleguidePage.js
@@ -1,0 +1,114 @@
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import { map, size } from 'lodash';
+import * as allExamples from '../../components/examples';
+
+import css from './StyleguidePage.css';
+
+const ALL = '*';
+
+const Example = props => {
+  const {
+    componentName,
+    exampleName,
+    component: ExampleComponent,
+    description,
+    props: exampleProps,
+  } = props;
+  const desc = description ? <p>Description: {description}</p> : null;
+  return (
+    <li>
+      <h2>
+        <Link to={`/styleguide/${componentName}`}>{componentName}</Link>/
+        <Link to={`/styleguide/${componentName}/${exampleName}`}>{exampleName}</Link>
+      </h2>
+      <span><Link to={`/styleguide/${componentName}/${exampleName}/raw`}>raw</Link></span>
+      {desc}
+      <div>
+        <ExampleComponent {...exampleProps} />
+      </div>
+    </li>
+  );
+};
+
+const { string, oneOfType, func, node, object, objectOf, shape } = PropTypes;
+
+Example.defaultProps = { description: null, props: {} };
+
+Example.propTypes = {
+  componentName: string.isRequired,
+  exampleName: string.isRequired,
+  component: oneOfType([ func, node ]).isRequired,
+  description: string,
+  props: object,
+};
+
+const Examples = props => {
+  const { examples } = props;
+  const toExamples = (exmpls, name) => (
+    <li key={name}>
+      <ul>
+        {
+          map(exmpls, (exmpl, exampleName) => (
+            <Example key={exampleName} componentName={name} exampleName={exampleName} {...exmpl} />
+          ))
+        }
+      </ul>
+    </li>
+  );
+  return (
+    <ul>
+      {map(examples, toExamples)}
+    </ul>
+  );
+};
+
+Examples.propTypes = { examples: objectOf(objectOf(object)).isRequired };
+
+const examplesFor = (examples, componentName, exampleName) => {
+  // All components, all examples
+  if (componentName === ALL) {
+    return examples;
+  }
+
+  // Specific component, all examples
+  const component = examples[componentName];
+  if (exampleName === ALL) {
+    return component ? { [componentName]: component } : {};
+  }
+
+  // Specific component, specific example
+  const example = component ? component[exampleName] : null;
+  return example ? { [componentName]: { [exampleName]: example } } : {};
+};
+
+const StyleguidePage = props => {
+  const { params } = props;
+  const component = params.component || ALL;
+  const example = params.example || ALL;
+  const raw = params.type === 'raw';
+  const examples = examplesFor(allExamples, component, example);
+
+  // Raw examples are rendered without any wrapper
+  if (raw && examples[component] && examples[component][example]) {
+    const { component: ExampleComponent, props: exampleProps } = examples[component][example];
+    return <ExampleComponent {...exampleProps} />;
+  } else if (raw) {
+    return <p>No example with filter {component}/{example}/raw</p>;
+  }
+
+  const html = size(examples) > 0
+    ? <Examples examples={examples} />
+    : <p>No examples with filter: {component}/{example}</p>;
+
+  return (
+    <section className={css.root}>
+      <h1><Link to="/styleguide">Styleguide</Link></h1>
+      {html}
+    </section>
+  );
+};
+
+StyleguidePage.propTypes = { params: shape({ component: string, example: string }).isRequired };
+
+export default StyleguidePage;

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -6,6 +6,7 @@ import InboxPage from './InboxPage/InboxPage';
 import LandingPage from './LandingPage/LandingPage';
 import ListingPage from './ListingPage/ListingPage';
 import ManageListingsPage from './ManageListingsPage/ManageListingsPage';
+import NotFoundPage from './NotFoundPage/NotFoundPage';
 import OrderPage from './OrderPage/OrderPage';
 import PasswordChangePage from './PasswordChangePage/PasswordChangePage';
 import PasswordForgottenPage from './PasswordForgottenPage/PasswordForgottenPage';
@@ -14,7 +15,7 @@ import ProfilePage from './ProfilePage/ProfilePage';
 import SalesConversationPage from './SalesConversationPage/SalesConversationPage';
 import SearchPage from './SearchPage/SearchPage';
 import SecurityPage from './SecurityPage/SecurityPage';
-import NotFoundPage from './NotFoundPage/NotFoundPage';
+import StyleguidePage from './StyleguidePage/StyleguidePage';
 import Topbar from './Topbar/Topbar';
 
 export {
@@ -35,5 +36,6 @@ export {
   SalesConversationPage,
   SearchPage,
   SecurityPage,
+  StyleguidePage,
   Topbar,
 };

--- a/src/routesConfiguration.js
+++ b/src/routesConfiguration.js
@@ -19,6 +19,7 @@ import {
   SalesConversationPage,
   SearchPage,
   SecurityPage,
+  StyleguidePage,
 } from './containers';
 
 // This is only used for testing that redirects work correct in the
@@ -195,6 +196,30 @@ const routesConfiguration = [
         component: SecurityPage,
       },
     ],
+  },
+  {
+    pattern: '/styleguide',
+    exactly: true,
+    name: 'Styleguide',
+    component: StyleguidePage,
+  },
+  {
+    pattern: '/styleguide/:component',
+    exactly: true,
+    name: 'StyleguideComponent',
+    component: StyleguidePage,
+  },
+  {
+    pattern: '/styleguide/:component/:example',
+    exactly: true,
+    name: 'StyleguideComponentExample',
+    component: StyleguidePage,
+  },
+  {
+    pattern: '/styleguide/:component/:example/:type',
+    exactly: true,
+    name: 'StyleguideComponentExampleRaw',
+    component: StyleguidePage,
   },
 ];
 


### PR DESCRIPTION
This PR adds a basic styleguide page that lists all components. Components can have any amount of examples exported in `ComponentName.example.js` as named exports.

The Styleguide lives within the application and supports filtering based on component and its examples. It also provides a path to render an example raw without any HTML wrappers.

This PR **does not implement** the following features that we probably want to add in the future:

 - Grouping components, filtering by groups
 - Styling
 - Menu/dropdown navigation
 - Interactive examples
 - Rendering/editing props
 - Documentation as this will probably change quite a bit later

## All components and examples:

<img width="681" alt="screen shot 2017-01-24 at 14 10 36" src="https://cloud.githubusercontent.com/assets/53923/22246764/0695df52-e23f-11e6-8a6a-a6e550819b17.png">

## All examples for the Hello component:
<img width="681" alt="screen shot 2017-01-24 at 14 10 54" src="https://cloud.githubusercontent.com/assets/53923/22246763/06924f4a-e23f-11e6-96a3-2154c2b380c2.png">

## HelloWorld example of the Hello component:
<img width="682" alt="screen shot 2017-01-24 at 14 11 06" src="https://cloud.githubusercontent.com/assets/53923/22246766/06b5a85a-e23f-11e6-8303-445c31b5e2d1.png">

## Raw HelloWorld example of the Hello component
<img width="681" alt="screen shot 2017-01-24 at 14 11 18" src="https://cloud.githubusercontent.com/assets/53923/22246765/06b2db34-e23f-11e6-8fee-e8f0b9d400fd.png">
