### PR TITLE
Enable Redux DevTools in client side dev mode

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { createStore } from 'redux';
 import createReducer from './reducers';
 
@@ -6,5 +7,11 @@ import createReducer from './reducers';
  * (like redux-saga or redux-thunk middleware)
  */
 export default function configureStore(initialState) {
+  const useReduxDevTools = process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' &&
+    window.__REDUX_DEVTOOLS_EXTENSION__;
+
+  if (useReduxDevTools) {
+    return createStore(createReducer(), initialState, window.__REDUX_DEVTOOLS_EXTENSION__());
+  }
   return createStore(createReducer(), initialState);
 }


### PR DESCRIPTION
This PR enables [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension) if it is installed. It is only enabled in dev mode in the client side.

The timetravel most likely won't work with our router at the moment, but seeing the store contents and dispatched actions should be useful enough to take this into use.

<img width="640" alt="screen shot 2017-01-25 at 10 11 13" src="https://cloud.githubusercontent.com/assets/53923/22282873/bba249e6-e2e7-11e6-9f4d-cc77d3243e8a.png">
