### PR TITLE
Enable configuring SDK in the ENV

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,16 @@
 const env = process.env.NODE_ENV;
 const dev = env !== 'production';
 
-const config = {
-  env,
-  dev,
-  sdk: { clientId: '08ec69f6-d37e-414d-83eb-324e94afddf0', baseUrl: 'http://localhost:8088' },
-};
+// To pass environment variables to the client app in the build
+// script, react-scripts (and the sharetribe-scripts fork of
+// react-scripts) require using the REACT_APP_ prefix to avoid
+// exposing server secrets to the client side.
+const sdkClientId = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID ||
+  '08ec69f6-d37e-414d-83eb-324e94afddf0';
+const sdkBaseUrl = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL || 'http://localhost:8088';
+
+// NOTE: only expose configuration that should be visible in the
+// client side, don't add any server secrets in this file.
+const config = { env, dev, sdk: { clientId: sdkClientId, baseUrl: sdkBaseUrl } };
 
 export default config;


### PR DESCRIPTION
This PR changes the client side config to read the SDK `clientId` and `baseUrl` from the environment. This enables configuring a deployment to use a specific API.