### PR TITLE
fix: empty array as relationship broke denormalization

### DIFF
--- a/src/util/data.js
+++ b/src/util/data.js
@@ -85,13 +85,19 @@ export const denormalisedEntities = (entities, type, ids) => {
           // an array of objects. We want to keep that form in the final
           // result.
           const hasMultipleRefs = Array.isArray(relRef.data);
-          const refs = hasMultipleRefs ? relRef.data : [relRef.data];
-          const relIds = refs.map(ref => ref.id);
-          const relType = refs[0].type;
-          const rels = denormalisedEntities(entities, relType, relIds);
+          const multipleRefsEmpty = hasMultipleRefs && relRef.data.length === 0;
+          if (!relRef.data || multipleRefsEmpty) {
+            // eslint-disable-next-line no-param-reassign
+            ent[relName] = hasMultipleRefs ? [] : null;
+          } else {
+            const refs = hasMultipleRefs ? relRef.data : [relRef.data];
+            const relIds = refs.map(ref => ref.id);
+            const relType = refs[0].type;
+            const rels = denormalisedEntities(entities, relType, relIds);
 
-          // eslint-disable-next-line no-param-reassign
-          ent[relName] = hasMultipleRefs ? rels : rels[0];
+            // eslint-disable-next-line no-param-reassign
+            ent[relName] = hasMultipleRefs ? rels : rels[0];
+          }
           return ent;
         },
         entityData,

--- a/src/util/data.test.js
+++ b/src/util/data.test.js
@@ -272,5 +272,26 @@ describe('data utils', () => {
         listing2,
       ]);
     });
+    it('denormalises multiple relationships when relationship data is empty', () => {
+      const user1 = createUser('user1');
+      const listing1 = createListing('listing1');
+      const listing1Relationships = {
+        author: { data: null },
+        images: { data: [] },
+      };
+      const listing1WithRelationships = { ...listing1, relationships: listing1Relationships };
+      const listing2 = createListing('listing2');
+      const listing3 = createListing('listing3');
+      const entities = {
+        listing: { listing1: listing1WithRelationships, listing2, listing3 },
+        user: { user1 },
+      };
+      const ids = [listing1.id, listing2.id];
+
+      expect(denormalisedEntities(entities, 'listing', ids)).toEqual([
+        { ...listing1, author: null, images: [] },
+        listing2,
+      ]);
+    });
   });
 });


### PR DESCRIPTION
If data is not defined or it's empty array, we'll print null or empty array.