### PR TITLE
Data loading: phase 1 in the client

### DIFF
--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -1,0 +1,55 @@
+import { showListingsSuccess } from '../../ducks/sdk.duck';
+
+// ================ Action types ================ //
+
+export const SHOW_LISTING_REQUEST = 'app/ListingPage/SHOW_LISTING_REQUEST';
+export const SHOW_LISTING_ERROR = 'app/ListingPage/SHOW_LISTING_ERROR';
+
+// ================ Reducer ================ //
+
+const initialState = {
+  id: null,
+  showListingError: null,
+};
+
+const listingPageReducer = (state = initialState, action = {}) => {
+  const { type, payload } = action;
+  switch (type) {
+    case SHOW_LISTING_REQUEST:
+      return { id: payload.id, showListingError: null };
+    case SHOW_LISTING_ERROR:
+      return { showListingError: payload };
+    default:
+      return state;
+  }
+};
+
+export default listingPageReducer;
+
+// ================ Action creators ================ //
+
+export const showListingRequest = id => ({
+  type: SHOW_LISTING_REQUEST,
+  payload: { id },
+});
+
+export const showListingError = e => ({
+  type: SHOW_LISTING_ERROR,
+  error: true,
+  payload: e,
+});
+
+export const showListing = listingId =>
+  (dispatch, getState, sdk) => {
+    dispatch(showListingRequest(listingId));
+    return sdk.listings
+      .show({ id: listingId, include: ['author', 'images'] })
+      .then(data => {
+        dispatch(showListingsSuccess(data));
+        return data;
+      })
+      .catch(e => {
+        dispatch(showListingError(e));
+        throw e;
+      });
+  };

--- a/src/containers/ListingPage/ListingPage.test.js
+++ b/src/containers/ListingPage/ListingPage.test.js
@@ -1,19 +1,64 @@
 import React from 'react';
+import { types } from 'sharetribe-sdk';
 import { createListing } from '../../util/test-data';
 import { fakeIntl, renderShallow } from '../../util/test-helpers';
 import { ListingPageComponent } from './ListingPage';
+import { showListingsSuccess } from '../../ducks/sdk.duck';
+import { showListingRequest, showListingError, showListing } from './ListingPage.duck';
+
+const { UUID } = types;
 
 describe('ListingPage', () => {
   it('matches snapshot', () => {
-    const entitiesData = { entities: { listing: { listing1: createListing('listing1') } } };
+    const marketplaceData = { entities: { listing: { listing1: createListing('listing1') } } };
     const tree = renderShallow(
       <ListingPageComponent
         params={{ slug: 'listing1-title', id: 'listing1' }}
-        entitiesData={entitiesData}
+        marketplaceData={marketplaceData}
         intl={fakeIntl}
         onLoadListing={l => l}
       />,
     );
     expect(tree).toMatchSnapshot();
+  });
+
+  describe('Duck', () => {
+    it('showListing() success', () => {
+      const id = new UUID('00000000-0000-0000-0000-000000000000');
+      const dispatch = jest.fn(action => action);
+      const response = { status: 200 };
+      const show = jest.fn(() => Promise.resolve(response));
+      const sdk = { listings: { show } };
+
+      return showListing(id)(dispatch, null, sdk).then(data => {
+        expect(data).toEqual(response);
+        expect(show.mock.calls).toEqual([[{ id, include: ['author', 'images'] }]]);
+        expect(dispatch.mock.calls).toEqual([
+          [showListingRequest(id)],
+          [showListingsSuccess(data)],
+        ]);
+      });
+    });
+
+    it('showListing() error', () => {
+      const id = new UUID('00000000-0000-0000-0000-000000000000');
+      const dispatch = jest.fn(action => action);
+      const error = new Error('fail');
+      const show = jest.fn(() => Promise.reject(error));
+      const sdk = { listings: { show } };
+
+      // Calling sdk.listings.show is expected to fail now
+
+      return showListing(id)(dispatch, null, sdk).then(
+        () => {
+          throw new Error('sdk.listings.show was supposed to fail!');
+        },
+        e => {
+          expect(e).toEqual(error);
+          expect(show.mock.calls).toEqual([[{ id, include: ['author', 'images'] }]]);
+          expect(dispatch.mock.calls).toEqual([[showListingRequest(id)], [showListingError(e)]]);
+        },
+      );
+    });
   });
 });

--- a/src/containers/reducers.js
+++ b/src/containers/reducers.js
@@ -3,9 +3,8 @@
  * We are following Ducks module proposition:
  * https://github.com/erikras/ducks-modular-redux
  */
-
-/* eslint-disable import/prefer-default-export */
 import EditListingPage from './EditListingPage/EditListingPage.duck';
+import ListingPage from './ListingPage/ListingPage.duck';
 import SearchPage from './SearchPage/SearchPage.duck';
 
-export { EditListingPage, SearchPage };
+export { EditListingPage, ListingPage, SearchPage };

--- a/src/routesConfiguration.js
+++ b/src/routesConfiguration.js
@@ -61,6 +61,7 @@ const routesConfiguration = [
         path: '/l/:slug/:id',
         exact: true,
         name: 'ListingPage',
+        loadData: (params, search) => ListingPage.loadData(params, search),
         component: props => <ListingPage {...props} />,
       },
       {


### PR DESCRIPTION
This PR implements the client side data loading of the first phase defined in the [data loading plan](https://gist.github.com/kpuputti/0e8ee3b355f55bb94138bbf9d79e5b25).

 - `ListingPage` defines a static `loadData` function
 - `loadData` function is also added to the `routesConfiguration.js`
 - `ListingPage.duck.js` is added that calls the `sdk.listings.show` method to fetch the required data for the given listing page
 - The `Routes` component calls the `loadData` function of a matched route if the user is allowed to see the page (i.e. the page doesn't require auth or the user is logged in)
 - The `Routes` component **does not** call the `loadData` when rendering within the `ServerApp` (this required some work since the test env contains browser globals...)