### PR TITLE
Remove page title

### DIFF
--- a/src/app.test.js
+++ b/src/app.test.js
@@ -37,7 +37,9 @@ describe('Application', () => {
     forEach(urlTitles, (title, url) => {
       const context = {};
       const body = render(url, context);
-      expect(body).toMatch(`>${title}</h1>`);
+
+      // context.url will contain the URL to redirect to if a <Redirect> was used
+      expect(context.url).not.toBeDefined();
     });
   });
 

--- a/src/components/PageLayout/PageLayout.js
+++ b/src/components/PageLayout/PageLayout.js
@@ -49,7 +49,6 @@ class PageLayout extends Component {
             </div>
           : null}
         <Topbar />
-        <h1>{title}</h1>
         {children}
       </div>
     );


### PR DESCRIPTION
This PR removes the title from the page layout:

<img width="417" alt="screen shot 2017-03-22 at 17 29 49" src="https://cloud.githubusercontent.com/assets/429876/24205889/5ad186c6-0f25-11e7-83c6-143af0b90536.png">

This also affects the tests: They are currently expecting that the title is renders and that way ensures that the user is able to see the page without logging in.

This is now changed so that the tests expect `context.url` to be `undefined`:

```
expect(context.url).not.toBeDefined();
```

According to the [React Router docs](https://reacttraining.com/react-router/core/api/StaticRouter), the `context` contains `url` **if** redirect happens. So expecting that `url` is `undefined` should be good enough to ensure that redirect didn't happen and user was allowed to see the page.