### PR TITLE
Add Chalkboard font (fallback to Comic Sans MS)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,15 @@
 @import "sanitize.css";
 
-html {
-  font-family: sans-serif;
+/* Base font */
+html, input, button {
+  /*
+     Use Chalkboard font. This font is available in Mac OSX. Fallback
+     to Comic Sans MS, "although it is not a perfect substitute font
+     since the two are not metrically compatible".
+
+     See: https://en.wikipedia.org/wiki/Chalkboard_(typeface)
+  */
+  font-family: "Chalkboard", "Comic Sans MS", sans-serif;
 }
 
 ul {
@@ -34,7 +42,6 @@ button {
   margin: 1rem 0;
   background-color: #eee;
   border: 1px solid #ddd;
-  font-family: sans-serif;
 
   &:hover {
     background-color: #ddd;


### PR DESCRIPTION
Use Chalkboard font. This font is available in Mac OSX. Fallback to Comic Sans MS, "although it is not a perfect substitute font since the two are not metrically compatible". 

See: https://en.wikipedia.org/wiki/Chalkboard_(typeface)

Screenshot:

<img width="675" alt="screen shot 2017-03-23 at 9 21 58" src="https://cloud.githubusercontent.com/assets/429876/24236356/358a8504-0faa-11e7-8959-6d9dd58dae42.png">
