### PR TITLE
Stripe TOS

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10,6 +10,8 @@
   "EditListingForm.pricePlaceholder": "$0.00",
   "EditListingForm.priceRequired": "You need to add a valid price.",
   "EditListingForm.titleRequired": "You need to add a title.",
+  "EditListingForm.stripeConnectedAccountAgreementLinkText": "Stripe Connected Account Agreement",
+  "EditListingForm.stripeTermsOfService": "By continuing, you agree to the {connectedAccountAgreementLink}.",
   "EditListingPage.titleCreateListing": "Create a listing",
   "EditListingPage.titleEditListing": "Edit listing",
   "HeroSearchForm.placeholder": "Search by location, e.g. New York",


### PR DESCRIPTION
This PR adds the Stripe Terms of Service to the new listing form when the bank account field is visible. The TOS link opens in a new tab/window.

Stripe's instructions for showing the TOS: https://stripe.com/docs/connect/updating-accounts#tos-acceptance

<img width="420" alt="screen shot 2017-04-04 at 14 58 26" src="https://cloud.githubusercontent.com/assets/53923/24655514/3816348e-1947-11e7-87d8-669a28f8bb56.png">

Builds on top of #101 so only the last commit is relevant to this PR.