### PR TITLE
Clear previous error when entering the checkout page

### DIFF
--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -63,7 +63,7 @@ export class ListingPageComponent extends Component {
 
     // Customize checkout page state with current listing and selected bookingDates
     const { setInitialValues } = findRouteByRouteName('CheckoutPage', flattenedRoutes);
-    dispatch(setInitialValues({ listing, bookingDates: values }));
+    dispatch(setInitialValues({ listing, bookingDates: values, initiateOrderError: null }));
 
     // Redirect to CheckoutPage
     history.push(


### PR DESCRIPTION
When an error happens in initiating the order in the checkout page, the error is stored in the Redux store. This error was not cleared when entering the checkout page again from another listing.