### PR TITLE
Change reduxForm call `form` argument name

### DIFF
--- a/src/components/DateInput/DateInput.example.js
+++ b/src/components/DateInput/DateInput.example.js
@@ -54,8 +54,10 @@ const FormComponent = props => {
 
 FormComponent.propTypes = formPropTypes;
 
+const defaultFormName = 'Styleguide.DateInput.Form';
+
 const Form = reduxForm({
-  form: 'Styleguide.DateInput.Form',
+  form: defaultFormName,
 })(FormComponent);
 
 export const Empty = {

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInput.example.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInput.example.js
@@ -17,8 +17,10 @@ const FormComponent = props => {
 
 FormComponent.propTypes = formPropTypes;
 
+const defaultFormName = 'Styleguide.LocationAutocompleteInput.Form';
+
 const Form = reduxForm({
-  form: 'Styleguide.LocationAutocompleteInput.Form',
+  form: defaultFormName,
 })(FormComponent);
 
 const PlaceInfo = props => {

--- a/src/containers/BookingDatesForm/BookingDatesForm.js
+++ b/src/containers/BookingDatesForm/BookingDatesForm.js
@@ -130,7 +130,7 @@ BookingDatesFormComponent.propTypes = {
   price: instanceOf(types.Money),
 };
 
-const formName = 'bookingDates';
+const formName = 'BookingDates';
 
 // When a field depends on the value of another field, we must connect
 // to the store and select the required values to inject to the

--- a/src/containers/ChangeAccountPasswordForm/ChangeAccountPasswordForm.js
+++ b/src/containers/ChangeAccountPasswordForm/ChangeAccountPasswordForm.js
@@ -20,4 +20,6 @@ const ChangeAccountPasswordForm = props => {
 
 ChangeAccountPasswordForm.propTypes = { ...formPropTypes };
 
-export default reduxForm({ form: 'changeAccountPassword' })(ChangeAccountPasswordForm);
+const defaultFormName = 'ChangeAccountPasswordForm';
+
+export default reduxForm({ form: defaultFormName })(ChangeAccountPasswordForm);

--- a/src/containers/ChangePasswordForm/ChangePasswordForm.js
+++ b/src/containers/ChangePasswordForm/ChangePasswordForm.js
@@ -17,4 +17,6 @@ const ChangePasswordForm = props => {
 
 ChangePasswordForm.propTypes = { ...formPropTypes };
 
-export default reduxForm({ form: 'changePassword' })(ChangePasswordForm);
+const defaultFormName = 'ChangePasswordForm';
+
+export default reduxForm({ form: defaultFormName })(ChangePasswordForm);

--- a/src/containers/LoginForm/LoginForm.js
+++ b/src/containers/LoginForm/LoginForm.js
@@ -73,8 +73,8 @@ LoginFormComponent.propTypes = {
   intl: intlShape.isRequired,
 };
 
-const formName = 'LoginForm';
+const defaultFormName = 'LoginForm';
 
-const LoginForm = compose(reduxForm({ form: formName }), injectIntl)(LoginFormComponent);
+const LoginForm = compose(reduxForm({ form: defaultFormName }), injectIntl)(LoginFormComponent);
 
 export default LoginForm;

--- a/src/containers/PasswordForgottenForm/PasswordForgottenForm.js
+++ b/src/containers/PasswordForgottenForm/PasswordForgottenForm.js
@@ -16,4 +16,6 @@ const PasswordForgottenForm = props => {
 
 PasswordForgottenForm.propTypes = { ...formPropTypes };
 
-export default reduxForm({ form: 'passwordForgotten' })(PasswordForgottenForm);
+const defaultFormName = 'PasswordForgottenForm';
+
+export default reduxForm({ form: defaultFormName })(PasswordForgottenForm);

--- a/src/containers/SearchForm/SearchForm.js
+++ b/src/containers/SearchForm/SearchForm.js
@@ -50,6 +50,6 @@ SearchForm.propTypes = {
   intl: intlShape.isRequired,
 };
 
-const formName = 'SearchForm';
+const defaultFormName = 'SearchForm';
 
-export default reduxForm({ form: formName })(injectIntl(SearchForm));
+export default reduxForm({ form: defaultFormName })(injectIntl(SearchForm));

--- a/src/containers/SignupForm/SignupForm.js
+++ b/src/containers/SignupForm/SignupForm.js
@@ -139,8 +139,8 @@ SignupFormComponent.propTypes = {
   intl: intlShape.isRequired,
 };
 
-const formName = 'SignupForm';
+const defaultFormName = 'SignupForm';
 
-const SignupForm = compose(reduxForm({ form: formName }), injectIntl)(SignupFormComponent);
+const SignupForm = compose(reduxForm({ form: defaultFormName }), injectIntl)(SignupFormComponent);
 
 export default SignupForm;


### PR DESCRIPTION
Since the form name can be overriden with component props, the initial name is just a default, this changes the var name to communicate that

**Note:** The names of the forms with selectors cannot be changed,
otherwise the selector doesn't find the correct data from the Redux
store with the initial form name.