### PR TITLE
Remove the overriden placeholder. Let the CurrencyInput handle it.

### DIFF
--- a/src/containers/EditListingPricingForm/EditListingPricingForm.js
+++ b/src/containers/EditListingPricingForm/EditListingPricingForm.js
@@ -30,9 +30,6 @@ export class EditListingPricingFormComponent extends Component {
     } = this.props;
 
     const priceRequiredMessage = intl.formatMessage({ id: 'EditListingPricingForm.priceRequired' });
-    const pricePlaceholderMessage = intl.formatMessage({
-      id: 'EditListingPricingForm.pricePlaceholder',
-    });
 
     return (
       <form onSubmit={handleSubmit}>
@@ -43,7 +40,6 @@ export class EditListingPricingFormComponent extends Component {
             component={this.EnhancedCurrencyInput}
             currencyConfig={config.currencyConfig}
             validate={[required(priceRequiredMessage)]}
-            placeholder={pricePlaceholderMessage}
           />
           <div className={css.perNight}>
             <FormattedMessage id="EditListingPricingForm.perNight" />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -47,7 +47,6 @@
   "EditListingPhotosForm.bankAccountNumberRequired": "You need to add a bank account number.",
   "EditListingPhotosPanel.title": "Add photos",
   "EditListingPricingForm.perNight": "per night",
-  "EditListingPricingForm.pricePlaceholder": "$0.00",
   "EditListingPricingForm.priceRequired": "You need to add a valid price.",
   "EditListingPricingPanel.title": "How much does it cost?",
   "EditListingPage.titleCreateListing": "Create a listing",


### PR DESCRIPTION
Fix PR fixes a bug that caused the price input placeholder to always be `$0.00`, no matter what currency was configured.

**The fix** implemented here is to remove the overriden placeholder for the `CurrencyInput` component. The `CurrencyInput` is already smart enough to render a correct placeholder, given the default value and currency configurations.

See: Default placeholder implementation in CurrencyInput: https://github.com/sharetribe/sharetribe-starter-app/blob/master/src/components/CurrencyInput/CurrencyInput.js#L168