### PR TITLE
Fixes an issue with modal in mobile menu, which sets display to block

### DIFF
--- a/src/components/ModalInMobile/ModalInMobile.css
+++ b/src/components/ModalInMobile/ModalInMobile.css
@@ -1,7 +1,5 @@
 /* ModalInMobile is visible by default */
-.modalInMobile {
-  display: block;
-}
+.modalInMobile { }
 
 /* Content is hidden in Mobile layout */
 .modalHidden {


### PR DESCRIPTION
- Causes issues, if the display should be flex or something else than block

**Before**

![dates-cutoff](https://cloud.githubusercontent.com/assets/429876/26198505/e92ccc20-3bce-11e7-8562-b0b807a10717.gif)

**After**

![dates-fixed](https://cloud.githubusercontent.com/assets/429876/26198513/efc905e4-3bce-11e7-89f8-a0d7d9355784.gif)
