### PR TITLE
Fix error when pasting account number with spaces

### DIFF
--- a/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.js
+++ b/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.js
@@ -23,7 +23,7 @@ const DEBOUNCE_WAIT_TIME = 1000;
 
 // Remove all whitespace from the given string
 const cleanedString = str => {
-  return str.replace(/\s/g, '');
+  return str ? str.replace(/\s/g, '') : '';
 };
 
 /**
@@ -211,7 +211,8 @@ class TokenInputFieldComponent extends Component {
   }
   handleRoutingNumberChange(e) {
     const { country, intl } = this.props;
-    const value = e.target.value.trim();
+    const rawValue = e.target.value;
+    const value = cleanedString(rawValue);
     let routingNumberError = null;
 
     // Validate the changed routing number
@@ -227,7 +228,7 @@ class TokenInputFieldComponent extends Component {
     }
 
     this.setState({
-      routingNumber: value,
+      routingNumber: rawValue,
       routingNumberError,
       stripeError: null,
     });
@@ -243,7 +244,8 @@ class TokenInputFieldComponent extends Component {
   }
   handleAccountNumberChange(e) {
     const { country, intl } = this.props;
-    const value = e.target.value.trim();
+    const rawValue = e.target.value;
+    const value = cleanedString(rawValue);
     let accountNumberError = null;
 
     // Validate the changed account number
@@ -259,7 +261,7 @@ class TokenInputFieldComponent extends Component {
     }
 
     this.setState({
-      accountNumber: value,
+      accountNumber: rawValue,
       accountNumberError,
       stripeError: null,
     });


### PR DESCRIPTION
Stripe seems to fail at least if the account number is copy pasted to
the input, and contains spaces (like in the placeholder text). The
solution is just to remove any whitespace from the numbers before
sending them to the Stripe API.

In addition, the trimming of the string is removed, allowing the user to manually add spaces to break down long numbers.