### PR TITLE
Generalise new/edit listing URL schema

### DIFF
--- a/src/app.test.js
+++ b/src/app.test.js
@@ -63,7 +63,7 @@ describe('Application', () => {
     const defaultAuthPath = '/signup';
     const urlRedirects = {
       '/l/new': defaultAuthPath,
-      '/l/listing-title-slug/1234/edit': defaultAuthPath,
+      '/l/listing-title-slug/1234/new/description': defaultAuthPath,
       '/l/listing-title-slug/1234/checkout': defaultAuthPath,
       '/u/1234/edit': defaultAuthPath,
       '/inbox': defaultAuthPath,

--- a/src/components/EditListingWizard/EditListingWizard.example.js
+++ b/src/components/EditListingWizard/EditListingWizard.example.js
@@ -8,10 +8,15 @@ const noop = () => null;
 export const NoPhotos = {
   component: EditListingWizard,
   props: {
+    params: {
+      id: 'some-id',
+      slug: 'some-slug',
+      type: 'edit',
+      tab: 'pricing',
+    },
     fetchInProgress: false,
     flattenedRoutes: flattenRoutes(routesConfiguration),
     history: { push: noop },
-    selectedTab: 'pricing',
     images: [],
     listing: createListing('listing1'),
     stripeConnected: true,

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -262,10 +262,7 @@ export class CheckoutPageComponent extends Component {
             <div className={css.detailsHeadings}>
               <h2 className={css.detailsTitle}>{listingTitle}</h2>
               <p className={css.detailsSubtitle}>
-                <FormattedMessage
-                  id="CheckoutPage.hostedBy"
-                  values={{ name: authorFirstName }}
-                />
+                <FormattedMessage id="CheckoutPage.hostedBy" values={{ name: authorFirstName }} />
               </p>
             </div>
             <h3 className={css.bookingBreakdownTitle}>

--- a/src/containers/EditListingPage/EditListingPage.js
+++ b/src/containers/EditListingPage/EditListingPage.js
@@ -69,13 +69,13 @@ export const EditListingPageComponent = props => {
     page,
     params,
     scrollingDisabled,
-    tab,
-    type,
   } = props;
+
+  const { id, type } = params;
+
   const isNew = type === 'new';
-  const hasIdParam = params && params.id;
-  const id = page.submittedListingId || (hasIdParam ? new types.UUID(params.id) : null);
-  const currentListing = getListing(id);
+  const listingId = page.submittedListingId || (id ? new types.UUID(id) : null);
+  const currentListing = getListing(listingId);
 
   const shouldRedirect = page.submittedListingId && currentListing;
   const showForm = isNew || currentListing;
@@ -83,8 +83,8 @@ export const EditListingPageComponent = props => {
   if (shouldRedirect) {
     // If page has already listingId (after submit) and current listings exist
     // redirect to listing page
-    const slug = currentListing ? createSlug(currentListing.attributes.title) : null;
-    return <NamedRedirect name="ListingPage" params={{ id: id.uuid, slug }} />;
+    const listingSlug = currentListing ? createSlug(currentListing.attributes.title) : null;
+    return <NamedRedirect name="ListingPage" params={{ id: listingId.uuid, slug: listingSlug }} />;
   } else if (showForm) {
     const { createListingsError = null, showListingsError = null, uploadImageError = null } = page;
     const errors = { createListingsError, showListingsError, uploadImageError };
@@ -120,6 +120,7 @@ export const EditListingPageComponent = props => {
         />
         <EditListingWizard
           className={css.wizard}
+          params={params}
           disabled={disableForm}
           errors={errors}
           fetchInProgress={fetchInProgress}
@@ -133,7 +134,6 @@ export const EditListingPageComponent = props => {
           onPayoutDetailsSubmit={onPayoutDetailsSubmit}
           onImageUpload={onImageUpload}
           onUpdateImageOrder={onUpdateImageOrder}
-          selectedTab={tab}
           currentUser={currentUser}
           onManageDisableScrolling={onManageDisableScrolling}
         />
@@ -160,11 +160,9 @@ EditListingPageComponent.defaultProps = {
   listingDraft: null,
   logoutError: null,
   notificationCount: 0,
-  params: null,
-  type: 'edit',
 };
 
-const { arrayOf, bool, func, instanceOf, number, object, shape, string } = PropTypes;
+const { arrayOf, bool, func, instanceOf, number, object, shape, string, oneOf } = PropTypes;
 
 EditListingPageComponent.propTypes = {
   authInfoError: instanceOf(Error),
@@ -187,12 +185,12 @@ EditListingPageComponent.propTypes = {
   onUpdateListingDraft: func.isRequired,
   page: object.isRequired,
   params: shape({
-    id: string,
-    slug: string,
-  }),
+    id: string.isRequired,
+    slug: string.isRequired,
+    type: oneOf(['new', 'edit']).isRequired,
+    tab: string.isRequired,
+  }).isRequired,
   scrollingDisabled: bool.isRequired,
-  tab: string.isRequired,
-  type: string,
 
   /* from withRouter */
   history: shape({

--- a/src/containers/EditListingPage/EditListingPage.test.js
+++ b/src/containers/EditListingPage/EditListingPage.test.js
@@ -10,6 +10,7 @@ describe('EditListingPageComponent', () => {
     const getListing = () => null;
     const tree = renderShallow(
       <EditListingPageComponent
+        params={{ id: 'id', slug: 'slug', type: 'new', tab: 'description' }}
         currentUserHasListings={false}
         isAuthenticated={false}
         authInProgress={false}

--- a/src/containers/EditListingPage/__snapshots__/EditListingPage.test.js.snap
+++ b/src/containers/EditListingPage/__snapshots__/EditListingPage.test.js.snap
@@ -48,7 +48,14 @@ exports[`EditListingPageComponent matches snapshot 1`] = `
     onPayoutDetailsSubmit={[Function]}
     onUpdateImageOrder={[Function]}
     onUpdateListingDraft={[Function]}
-    rootClassName={null}
-    selectedTab="description" />
+    params={
+      Object {
+        "id": "id",
+        "slug": "slug",
+        "tab": "description",
+        "type": "new",
+      }
+    }
+    rootClassName={null} />
 </withRouter(PageLayout)>
 `;

--- a/src/routesConfiguration.js
+++ b/src/routesConfiguration.js
@@ -23,6 +23,10 @@ import {
   EmailVerificationPage,
 } from './containers';
 
+// https://en.wikipedia.org/wiki/Universally_unique_identifier#Nil_UUID
+const draftId = '00000000-0000-0000-0000-000000000000';
+const draftSlug = 'draft';
+
 const RedirectToLandingPage = () => <NamedRedirect name="LandingPage" />;
 
 const routesConfiguration = [
@@ -90,42 +94,19 @@ const routesConfiguration = [
         path: '/l/new',
         exact: true,
         name: 'NewListingPage',
-        component: props => <EditListingPage {...props} type={'new'} tab={'description'} />,
+        component: () => (
+          <NamedRedirect
+            name="EditListingPage"
+            params={{ slug: draftSlug, id: draftId, type: 'new', tab: 'description' }}
+          />
+        ),
       },
       {
         auth: true,
-        path: '/l/new-description', // TODO should be l/:slug/:id/description
-        exact: true,
-        name: 'EditListingDescriptionPage',
-        component: props => <EditListingPage {...props} type={'new'} tab={'description'} />,
-      },
-      {
-        auth: true,
-        path: '/l/new-location', // TODO should be l/:slug/:id/location
-        exact: true,
-        name: 'EditListingLocationPage',
-        component: props => <EditListingPage {...props} type={'new'} tab={'location'} />,
-      },
-      {
-        auth: true,
-        path: '/l/new-pricing', // TODO should be l/:slug/:id/pricing
-        exact: true,
-        name: 'EditListingPricingPage',
-        component: props => <EditListingPage {...props} type={'new'} tab={'pricing'} />,
-      },
-      {
-        auth: true,
-        path: '/l/new-photos', // TODO should be l/:slug/:id/photos
-        exact: true,
-        name: 'EditListingPhotosPage',
-        component: props => <EditListingPage {...props} type={'new'} tab={'photos'} />,
-      },
-      {
-        auth: true,
-        path: '/l/:slug/:id/edit',
+        path: '/l/:slug/:id/:type/:tab',
         exact: true,
         name: 'EditListingPage',
-        component: props => <EditListingPage {...props} type={'edit'} />,
+        component: props => <EditListingPage {...props} />,
       },
     ],
   },


### PR DESCRIPTION
This PR changes the listing creation URL schema to include temporary draft id and slug. This enables making the wizard generic for creating new listings and editing existing listings.

<img width="730" alt="screen shot 2017-08-10 at 12 14 40" src="https://user-images.githubusercontent.com/53923/29163557-8c52649a-7dc5-11e7-8ce1-aaa4108ed057.png">
