### PR TITLE
Safari bug: sticky didn't work with button nor with bottom position

### DIFF
--- a/src/components/SearchResultsPanel/SearchResultsPanel.js
+++ b/src/components/SearchResultsPanel/SearchResultsPanel.js
@@ -20,6 +20,7 @@ const SearchResultsPanel = props => {
   return (
     <div className={classes}>
       <div className={css.listingCards}>
+        {props.children}
         {listings.map(l => (
           <ListingCard
             className={css.listingCard}
@@ -28,7 +29,6 @@ const SearchResultsPanel = props => {
             currencyConfig={currencyConfig}
           />
         ))}
-        {props.children}
       </div>
       {paginationLinks}
     </div>

--- a/src/containers/SearchPage/SearchPage.css
+++ b/src/containers/SearchPage/SearchPage.css
@@ -83,9 +83,11 @@
   @apply --marketplaceH4FontStyles;
 
   /* Positioning */
+  /* Safari didn't like bottom: 48px; -> hence calc from top */
   position: fixed;
-  bottom: 48px;
+  top: calc(100vh - 100px);
   left: 50vw;
+  width: 150px;
   transform: translateX(-50%);
   margin-top: 0;
   margin-bottom: 0;
@@ -119,6 +121,7 @@
 
 .openMobileMapSticky {
   position: sticky;
+  z-index: 1;
 }
 
 .mapPanel {

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -227,6 +227,9 @@ export class SearchPageComponent extends Component {
 
     const searchParamsForPagination = parse(location.search);
 
+    // N.B. openMobileMap button is sticky.
+    // For some reason, stickyness doesn't work on Safari, if the element is <button>
+    /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
       <PageLayout
         authInfoError={authInfoError}
@@ -266,7 +269,7 @@ export class SearchPageComponent extends Component {
                 pagination={listingsAreLoaded ? pagination : null}
                 search={searchParamsForPagination}
               >
-                <button
+                <div
                   className={classNames(css.openMobileMap, {
                     [css.openMobileMapSticky]: listings.length > 0,
                   })}
@@ -278,7 +281,7 @@ export class SearchPageComponent extends Component {
                 >
                   <MapIcon className={css.openMobileMapIcon} />
                   <FormattedMessage id="SearchPage.openMapView" />
-                </button>
+                </div>
               </SearchResultsPanel>
             </div>
           </div>
@@ -297,6 +300,7 @@ export class SearchPageComponent extends Component {
         </div>
       </PageLayout>
     );
+    /* eslint-enable jsx-a11y/no-static-element-interactions */
   }
 }
 

--- a/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
+++ b/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
@@ -61,7 +61,7 @@ exports[`SearchPageComponent matches snapshot 1`] = `
           }
           rootClassName={null}
           search={Object {}}>
-          <button
+          <div
             className=""
             onClick={[Function]}>
             <MapIcon
@@ -69,7 +69,7 @@ exports[`SearchPageComponent matches snapshot 1`] = `
             <FormattedMessage
               id="SearchPage.openMapView"
               values={Object {}} />
-          </button>
+          </div>
         </SearchResultsPanel>
       </div>
     </div>


### PR DESCRIPTION
Safari lost sticky functionality if the element was button and also if the element was last and bottom positioned. No idea why that happens - this is a quick fix, before someone figures out a better solution.