### PR TITLE
Change layout for add listing button

### DIFF
--- a/src/components/TopbarMobileMenu/TopbarMobileMenu.css
+++ b/src/components/TopbarMobileMenu/TopbarMobileMenu.css
@@ -2,13 +2,14 @@
 
 :root{
   --topMarginMobileMenu: 96px;
-  --buttonHeight: 61px;
 }
 
 .root {
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   padding: 0 24px;
 }
 
@@ -18,12 +19,18 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  /* 113 for footer and an extra 67 to get scrolling work in mobile safari */
+  margin-bottom: 180px;
 }
 
 .footer {
-  flex-basis: var(--buttonHeight);
-  flex-shrink: 0;
-  padding-bottom: 24px;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  padding: 24px;
+  background-color: var(--matterColorLight);
+  box-shadow: var(--boxShadowTop);
 }
 
 .avatar {


### PR DESCRIPTION
Make the add listing button in mobile menu always visible so that it is not blocked by mobile Safari's bottom bar and other content scrolls behind it.

So form this:

![before](https://user-images.githubusercontent.com/57473/30628975-18246e00-9de2-11e7-9f4f-0c7059889967.PNG)

 
to this:

![after](https://user-images.githubusercontent.com/57473/30628979-1c0b7fd6-9de2-11e7-8081-dfce91b9df7c.PNG)

