### PR TITLE
Fix broken buttons (wrong flex direction)

### DIFF
--- a/src/components/HeroSection/HeroSection.css
+++ b/src/components/HeroSection/HeroSection.css
@@ -61,7 +61,6 @@
   width: 16px;
   height: 16px;
   margin-right: 10px;
-  margin-top: 5px;
 }
 
 .desktopSearchForm {

--- a/src/marketplace.css
+++ b/src/marketplace.css
@@ -158,7 +158,7 @@
     margin: 0;
 
     /* Center contents within flexbox */
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
     justify-content: center;
 


### PR DESCRIPTION
PR #421 broken the landing page and edit/create listing button layouts. This PR fixes the broken buttons.

## Screenshots

**Landing page from:**

<img width="393" alt="screen shot 2017-09-21 at 9 50 56" src="https://user-images.githubusercontent.com/53923/30682470-6e725508-9eb2-11e7-9349-68a5b095b3e5.png">

**to:**

<img width="387" alt="screen shot 2017-09-21 at 9 49 43" src="https://user-images.githubusercontent.com/53923/30682401-383a2bf0-9eb2-11e7-99e7-9ea63328194c.png">

**Edit/create listing page from:**

<img width="259" alt="screen shot 2017-09-21 at 9 43 13" src="https://user-images.githubusercontent.com/53923/30682412-459ea4f6-9eb2-11e7-91c4-a6d9e1e23411.png">

**to:**

<img width="249" alt="screen shot 2017-09-21 at 9 43 36" src="https://user-images.githubusercontent.com/53923/30682411-459c468e-9eb2-11e7-80b8-491f72aa733f.png">

