### PR TITLE
imageId is not a field in the form.

### DIFF
--- a/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
+++ b/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
@@ -55,12 +55,13 @@ export class ProfileSettingsPageComponent extends Component {
     } = this.props;
 
     const handleSubmit = values => {
-      const { firstName, lastName, profileImage } = values;
+      const { firstName, lastName } = values;
       const name = { firstName, lastName };
+      const uploadedImage = this.props.image;
 
       // Update profileImage only if file system has been accessed
-      const updatedValues = profileImage.imageId && profileImage.file
-        ? { ...name, profileImageId: profileImage.imageId }
+      const updatedValues = uploadedImage.imageId && uploadedImage.file
+        ? { ...name, profileImageId: uploadedImage.imageId }
         : name;
 
       onUpdateProfile(updatedValues).then(() => {


### PR DESCRIPTION
Previously values were populated with correct profileImage. 
(Profile image Id is not added to form since profile image is anyway handled on page/duck level.)

Edit: and one more fix added... https://github.com/sharetribe/sharetribe-starter-app/pull/437