### PR TITLE
Try to keep auth info up to date when fetching current user

### DIFF
--- a/src/ducks/Auth.test.js
+++ b/src/ducks/Auth.test.js
@@ -1,4 +1,4 @@
-import { clearCurrentUser, currentUserShowRequest } from './user.duck';
+import { clearCurrentUser, currentUserShowRequest, currentUserShowSuccess } from './user.duck';
 import reducer, {
   authenticationInProgress,
   authInfoSuccess,
@@ -192,10 +192,10 @@ describe('Auth duck', () => {
 
   describe('login thunk', () => {
     it('should dispatch success and fetch current user', () => {
+      const initialState = reducer();
       const getState = () => ({ Auth: initialState });
       const sdk = { login: jest.fn(() => Promise.resolve({})) };
       const dispatch = createFakeDispatch(getState, sdk);
-      const initialState = reducer();
       const username = 'x.x@example.com';
       const password = 'pass';
 
@@ -205,6 +205,11 @@ describe('Auth duck', () => {
           loginRequest(),
           loginSuccess(),
           currentUserShowRequest(),
+
+          // Test restriction: Since the getState mock always returns
+          // the initial state, user isn't marked as logged in and
+          // current user is still null.
+          currentUserShowSuccess(null),
         ]);
       });
     });
@@ -355,6 +360,11 @@ describe('Auth duck', () => {
           loginRequest(),
           loginSuccess(),
           currentUserShowRequest(),
+
+          // Test restriction: Since the getState mock always returns
+          // the initial state, user isn't marked as logged in and
+          // current user is still null.
+          currentUserShowSuccess(null),
         ]);
       });
     });

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -1,3 +1,4 @@
+import { authInfo } from './Auth.duck';
 import { updatedEntities, denormalisedEntities } from '../util/data';
 import { TX_TRANSITION_PREAUTHORIZE } from '../util/propTypes';
 
@@ -323,7 +324,8 @@ export const fetchCurrentUser = () =>
     const { isAuthenticated } = getState().Auth;
 
     if (!isAuthenticated) {
-      // Ignore when not logged in, current user should be null
+      // Make sure current user is null
+      dispatch(currentUserShowSuccess(null));
       return Promise.resolve({});
     }
 
@@ -344,8 +346,14 @@ export const fetchCurrentUser = () =>
         if (!currentUser.attributes.emailVerified) {
           dispatch(fetchCurrentUserHasOrders());
         }
+
+        // Make sure auth info is up to date
+        dispatch(authInfo());
       })
       .catch(e => {
+        // Make sure auth info is up to date
+        dispatch(authInfo());
+
         // TODO: dispatch flash message: "Something went wrong while retrieving user info"
         dispatch(currentUserShowError(e));
       });


### PR DESCRIPTION
This PR might fix the weird authentication state reported in testing.

At least it fixed the case where the cookie was present (and thus we thought the user was logged in) but it was invalid (and thus fetching the current user failed) which resulted in the app showing the user being logged in, but no user data was present. I managed to test this by manually editing the cookie into something invalid.