### PR TITLE
Add plurality to manage listings title

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -216,7 +216,7 @@
   "ManageListingsPage.noResults": "You don't have any listings.",
   "ManageListingsPage.profileSettings": "Profile settings",
   "ManageListingsPage.queryError": "Query failed. Please try again.",
-  "ManageListingsPage.youHaveListings": "You have {count} listings",
+  "ManageListingsPage.youHaveListings": "You have {count} {count, plural, one {listing} other {listings}}",
   "ManageListingsPage.yourListings": "Your listings",
   "MapPriceMarker.unsupportedPrice": "({currency})",
   "Modal.close": "CLOSE",


### PR DESCRIPTION
Present the manage listings page title in singular or plural form depending of the number of listings belonging to the user.

So, one listing:
![screen shot 2017-10-04 at 12 52 15](https://user-images.githubusercontent.com/57473/31170069-6d569728-a903-11e7-8717-5dffa97926ef.png)

And multiple listings:
![screen shot 2017-10-04 at 12 52 58](https://user-images.githubusercontent.com/57473/31170086-7a9bff22-a903-11e7-9a92-9bd255e19e22.png)
