### PR TITLE
Prevent file drop to avoid loosing data

### DIFF
--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -14,15 +14,28 @@ const scrollToTop = () => {
   window.scrollTo(0, 0);
 };
 
+const preventDefault = e => {
+  e.preventDefault();
+};
+
 class PageComponent extends Component {
   componentDidMount() {
     this.historyUnlisten = this.props.history.listen(() => scrollToTop());
+
+    // By default a dropped file is loaded in the browser window as a
+    // file URL. We want to prevent this since it might loose a lot of
+    // data the user has typed but not yet saved. Preventing requires
+    // handling both dragover and drop events.
+    document.addEventListener('dragover', preventDefault);
+    document.addEventListener('drop', preventDefault);
   }
 
   componentWillUnmount() {
     if (this.historyUnlisten) {
       this.historyUnlisten();
     }
+    document.removeEventListener('dragover', preventDefault);
+    document.removeEventListener('drop', preventDefault);
   }
 
   render() {


### PR DESCRIPTION
This PR implements preventing all file drops to the UI to avoid loosing data e.g. in listing creation when the browser would load the file URL.