### PR TITLE
Fix bounce scroll showing page contents from behind modal

### DIFF
--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -17,6 +17,10 @@
   & .scrollLayer {
     @apply --marketplaceModalRootStyles;
 
+    /* Add default background color to avoid bouncing scroll showing the
+   page contents from behind the modal. */
+    background-color: var(--matterColorLight);
+
     /* Additional styles for the modal window, dimming the background and positioning the modal */
     min-height: 100vh;
     overflow: auto;


### PR DESCRIPTION
## Before

![bounce-peek](https://user-images.githubusercontent.com/53923/31269192-164be542-aa88-11e7-9c31-6491445aa7f3.gif)

## After

![bounce-fixed-clean](https://user-images.githubusercontent.com/53923/31269259-6232c516-aa88-11e7-953e-46eb2d4ac8fc.gif)

