### PR TITLE
Fix booking of user's own listings

### DIFF
--- a/src/containers/BookingDatesForm/BookingDatesForm.js
+++ b/src/containers/BookingDatesForm/BookingDatesForm.js
@@ -107,7 +107,7 @@ export class BookingDatesFormComponent extends Component {
       e.preventDefault();
       this.setState({ focusedInput: END_DATE });
     } else {
-      this.props.handleSubmit();
+      this.props.handleSubmit(e);
     }
   }
 


### PR DESCRIPTION
The PR #477 changed the booking button behaviour on listing page but also broke the handling of users booking their own listings.

This PR fixes this by passing the submit event on to the parent component form the `BookingDatesForm` component.