### PR TITLE
Added medium italic font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,6 +47,14 @@
 
       @font-face {
           font-family: 'sofiapro';
+          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-mediumit-webfont.woff2') format('woff2'),
+               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-mediumit-webfont.woff') format('woff');
+          font-weight: 500; /* Medium italics */
+          font-style: italic;
+      }
+
+      @font-face {
+          font-family: 'sofiapro';
           src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff2') format('woff2'),
                url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff') format('woff');
           font-weight: 600; /* SemiBold */


### PR DESCRIPTION
This adds medium italic font.

N.B. **I didn't add this to FontFaceObserver loading strategy**: I think that would needlessly slow down initial font-loading. So, in a rare situation where medium-italic font is not loaded, browser will show fauxs-italic first before `@font-face` style is ready to show actual medium-italic.