### PR TITLE
Add test for canceled Booking breakdown

### DIFF
--- a/src/components/BookingBreakdown/BookingBreakdown.example.js
+++ b/src/components/BookingBreakdown/BookingBreakdown.example.js
@@ -321,3 +321,49 @@ export const ProviderSaleDelivered = {
     }),
   },
 };
+
+export const ProviderSaleCanceled = {
+  component: BookingBreakdown,
+  props: {
+    userRole: 'provider',
+    transaction: exampleTransaction({
+      lastTransition: propTypes.TX_TRANSITION_CANCEL,
+      payinTotal: new Money(0, 'USD'),
+      payoutTotal: new Money(0, 'USD'),
+      lineItems: [
+        {
+          code: 'line-item/night',
+          quantity: new Decimal(1),
+          unitPrice: new Money(4500, 'USD'),
+          lineTotal: new Money(4500, 'USD'),
+          reversal: false,
+        },
+        {
+          code: 'line-item/night',
+          quantity: new Decimal(-1),
+          unitPrice: new Money(4500, 'USD'),
+          lineTotal: new Money(-4500, 'USD'),
+          reversal: true,
+        },
+        {
+          code: 'line-item/provider-commission',
+          quantity: new Decimal(1),
+          unitPrice: new Money(-2000, 'USD'),
+          lineTotal: new Money(-2000, 'USD'),
+          reversal: false,
+        },
+        {
+          code: 'line-item/provider-commission',
+          quantity: new Decimal(-1),
+          unitPrice: new Money(2000, 'USD'),
+          lineTotal: new Money(-2000, 'USD'),
+          reversal: true,
+        },
+      ],
+    }),
+    booking: exampleBooking({
+      start: new Date(Date.UTC(2017, 3, 14)),
+      end: new Date(Date.UTC(2017, 3, 15)),
+    }),
+  },
+};

--- a/src/components/BookingBreakdown/BookingBreakdown.test.js
+++ b/src/components/BookingBreakdown/BookingBreakdown.test.js
@@ -111,4 +111,52 @@ describe('BookingBreakdown', () => {
     );
     expect(tree).toMatchSnapshot();
   });
+  it('provider canceled transaction data matches snapshot', () => {
+    const tree = renderDeep(
+      <BookingBreakdownComponent
+        userRole="provider"
+        transaction={exampleTransaction({
+          lastTransition: propTypes.TX_TRANSITION_CANCEL,
+          payinTotal: new Money(0, 'USD'),
+          payoutTotal: new Money(0, 'USD'),
+          lineItems: [
+            {
+              code: 'line-item/night',
+              quantity: new Decimal(2),
+              lineTotal: new Money(2000, 'USD'),
+              unitPrice: new Money(1000, 'USD'),
+              reversal: false,
+            },
+            {
+              code: 'line-item/night',
+              quantity: new Decimal(-2),
+              lineTotal: new Money(-2000, 'USD'),
+              unitPrice: new Money(1000, 'USD'),
+              reversal: true,
+            },
+            {
+              code: 'line-item/provider-commission',
+              quantity: new Decimal(1),
+              lineTotal: new Money(-200, 'USD'),
+              unitPrice: new Money(-200, 'USD'),
+              reversal: false,
+            },
+            {
+              code: 'line-item/provider-commission',
+              quantity: new Decimal(-1),
+              lineTotal: new Money(200, 'USD'),
+              unitPrice: new Money(-200, 'USD'),
+              reversal: true,
+            },
+          ],
+        })}
+        booking={createBooking('example-booking', {
+          start: new Date(Date.UTC(2017, 3, 14)),
+          end: new Date(Date.UTC(2017, 3, 16)),
+        })}
+        intl={fakeIntl}
+      />
+    );
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/BookingBreakdown/__snapshots__/BookingBreakdown.test.js.snap
+++ b/src/components/BookingBreakdown/__snapshots__/BookingBreakdown.test.js.snap
@@ -148,6 +148,112 @@ exports[`BookingBreakdown pretransaction data matches snapshot 1`] = `
 </div>
 `;
 
+exports[`BookingBreakdown provider canceled transaction data matches snapshot 1`] = `
+<div
+  className=""
+>
+  <div
+    className={undefined}
+  >
+    <span
+      className={undefined}
+    >
+      <span>
+        Price per night
+      </span>
+    </span>
+    <span
+      className={undefined}
+    >
+      10
+    </span>
+  </div>
+  <div
+    className={undefined}
+  >
+    <span
+      className={undefined}
+    >
+      <span>
+        <span
+          className={undefined}
+        >
+          2017-04-14
+        </span>
+         – 
+        <span
+          className={undefined}
+        >
+          2017-04-16
+        </span>
+      </span>
+    </span>
+    <span
+      className={undefined}
+    >
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "2 nights",
+          }
+        }
+      />
+    </span>
+  </div>
+  <div
+    className={undefined}
+  >
+    <span
+      className={undefined}
+    >
+      <span>
+        Subtotal
+      </span>
+    </span>
+    <span
+      className={undefined}
+    >
+      20
+    </span>
+  </div>
+  <div
+    className={undefined}
+  >
+    <span
+      className={undefined}
+    >
+      <span>
+        Refund
+      </span>
+    </span>
+    <span
+      className={undefined}
+    >
+      -20
+    </span>
+  </div>
+  <hr
+    className={undefined}
+  />
+  <div
+    className={undefined}
+  >
+    <div
+      className={undefined}
+    >
+      <span>
+        Total price
+      </span>
+    </div>
+    <div
+      className={undefined}
+    >
+      0
+    </div>
+  </div>
+</div>
+`;
+
 exports[`BookingBreakdown provider transaction data matches snapshot 1`] = `
 <div
   className=""


### PR DESCRIPTION
In one previous PR review, there was discussion to add an example and test for refunded state in BookingBreakdown.