### PR TITLE
Fix error when data was being loaded while logout was in progress

### DIFF
--- a/src/ducks/Auth.duck.js
+++ b/src/ducks/Auth.duck.js
@@ -151,15 +151,16 @@ export const logout = () => (dispatch, getState, sdk) => {
   }
   dispatch(logoutRequest());
 
-  // Not that the thunk does not reject when the logout fails, it
+  // Note that the thunk does not reject when the logout fails, it
   // just dispatches the logout error action.
   return sdk
     .logout()
-    .then(() => dispatch(clearCurrentUser()))
-    .then(() => dispatch(logoutSuccess()))
     .then(() => {
-      dispatch(userLogout());
+      // The order of the dispatched actions
+      dispatch(logoutSuccess());
+      dispatch(clearCurrentUser());
       log.clearUserId();
+      dispatch(userLogout());
     })
     .catch(e => dispatch(logoutError(storableError(e))));
 };

--- a/src/ducks/Auth.test.js
+++ b/src/ducks/Auth.test.js
@@ -274,8 +274,8 @@ describe('Auth duck', () => {
         expect(sdk.logout.mock.calls.length).toEqual(1);
         expect(dispatch.mock.calls).toEqual([
           [logoutRequest()],
-          [clearCurrentUser()],
           [logoutSuccess()],
+          [clearCurrentUser()],
           [userLogout()],
         ]);
       });


### PR DESCRIPTION
The Routes component skips calling the possible loadData of a page if
the logout is in progress. However, the logoutSuccess and the
clearCurrentUser actions were dispatched in an order that cleared the
user from the store before the logout was marked done.

The fix was to order the actions so that the logout is marked done
first and then all the cleanup is done.

A better solution in the future would be to batch actions so that
extra render loops are avoided when dispatching multiple actions at
once.