### PR TITLE
Keep listing page mobile tab state in the URL

### DIFF
--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -97,14 +97,44 @@ ActionBar.propTypes = {
 
 ActionBar.displayName = 'ActionBar';
 
+const gotoBookTab = (history, listing) => {
+  if (!listing.id) {
+    // Listing not fully loaded yet
+    return;
+  }
+  const routes = routeConfiguration();
+  history.push(
+    createResourceLocatorString(
+      'ListingPageBook',
+      routes,
+      { id: listing.id.uuid, slug: createSlug(listing.attributes.title) },
+      {}
+    )
+  );
+};
+
+const gotoListingTab = (history, listing) => {
+  if (!listing.id) {
+    // Listing not fully loaded yet
+    return;
+  }
+  const routes = routeConfiguration();
+  history.push(
+    createResourceLocatorString(
+      'ListingPage',
+      routes,
+      { id: listing.id.uuid, slug: createSlug(listing.attributes.title) },
+      {}
+    )
+  );
+};
+
 // TODO: price unit (per x), custom fields, contact, reviews
 // N.B. All the presentational content needs to be extracted to their own components
 export class ListingPageComponent extends Component {
   constructor(props) {
     super(props);
-    const tab = props.tab;
     this.state = {
-      isBookingModalOpenOnMobile: tab && tab === 'book',
       pageClassNames: [],
       imageCarouselOpen: false,
     };
@@ -116,8 +146,6 @@ export class ListingPageComponent extends Component {
     const { history, getListing, params, useInitialValues } = this.props;
     const listingId = new UUID(params.id);
     const listing = getListing(listingId);
-
-    this.setState({ isBookingModalOpenOnMobile: false });
 
     const { bookingDates } = values;
 
@@ -147,6 +175,7 @@ export class ListingPageComponent extends Component {
 
   render() {
     const {
+      tab,
       currentUser,
       getListing,
       intl,
@@ -155,6 +184,7 @@ export class ListingPageComponent extends Component {
       params,
       scrollingDisabled,
       showListingError,
+      history,
     } = this.props;
     const listingId = new UUID(params.id);
     const currentListing = ensureListing(getListing(listingId));
@@ -281,6 +311,10 @@ export class ListingPageComponent extends Component {
       </div>
     );
 
+    const handleMobileBookModalClose = () => {
+      gotoListingTab(history, currentListing);
+    };
+
     const handleBookingSubmit = values => {
       const isClosed = currentListing.attributes.closed;
       if (isOwnListing || isClosed) {
@@ -297,7 +331,7 @@ export class ListingPageComponent extends Component {
       if (isOwnListing || isClosed) {
         window.scrollTo(0, 0);
       } else {
-        this.setState({ isBookingModalOpenOnMobile: true });
+        gotoBookTab(history, currentListing);
       }
     };
 
@@ -425,8 +459,8 @@ export class ListingPageComponent extends Component {
                   className={css.modalInMobile}
                   containerClassName={css.modalContainer}
                   id="BookingDatesFormInModal"
-                  isModalOpenOnMobile={this.state.isBookingModalOpenOnMobile}
-                  onClose={() => this.setState({ isBookingModalOpenOnMobile: false })}
+                  isModalOpenOnMobile={tab === 'book'}
+                  onClose={handleMobileBookModalClose}
                   showAsModalMaxWidth={MODAL_BREAKPOINT}
                   onManageDisableScrolling={onManageDisableScrolling}
                 >

--- a/src/routeConfiguration.js
+++ b/src/routeConfiguration.js
@@ -39,7 +39,11 @@ const RedirectToLandingPage = () => <NamedRedirect name="LandingPage" />;
 // See behaviour from Routes.js where Route is created.
 const routeConfiguration = () => {
   return [
-    { path: '/', name: 'LandingPage', component: props => <LandingPage {...props} /> },
+    {
+      path: '/',
+      name: 'LandingPage',
+      component: props => <LandingPage {...props} />,
+    },
     {
       path: '/s',
       name: 'SearchPage',
@@ -77,7 +81,7 @@ const routeConfiguration = () => {
     },
     {
       path: '/l/:slug/:id/book',
-      name: 'ListingPage',
+      name: 'ListingPageBook',
       component: props => <ListingPage {...props} tab="book" />,
       loadData: ListingPage.loadData,
     },

--- a/src/util/routes.js
+++ b/src/util/routes.js
@@ -103,16 +103,28 @@ export const canonicalRoutePath = (routes, location) => {
 
   const matches = matchPathname(pathname, routes);
   const isListingRoute = matches.length === 1 && matches[0].route.name === 'ListingPage';
+  const isListingBookRoute = matches.length === 1 && matches[0].route.name === 'ListingPageBook';
 
   if (isListingRoute) {
     // Remove the dynamic slug from the listing page canonical URL
 
     const parts = pathname.split('/');
+
     if (parts.length !== 4) {
-      throw new Error('Expecting ListingPage pathname to have 4 parts');
+      throw new Error('Expected ListingPage route to have 4 parts');
     }
     const canonicalListingPathname = `/${parts[1]}/${parts[3]}`;
     return `${canonicalListingPathname}${search}${hash}`;
+  } else if (isListingBookRoute) {
+    // Remove the dynamic slug from the listing book page canonical URL
+
+    const parts = pathname.split('/');
+
+    if (parts.length !== 5) {
+      throw new Error('Expected ListingPageBook route to have 5 parts');
+    }
+    const canonicalListingBookPathname = `/${parts[1]}/${parts[3]}/${parts[4]}`;
+    return `${canonicalListingBookPathname}${search}${hash}`;
   }
 
   return `${pathname}${search}${hash}`;

--- a/src/util/routes.test.js
+++ b/src/util/routes.test.js
@@ -90,6 +90,17 @@ describe('util/routes.js', () => {
         '/l/00000000-0000-0000-0000-000000000000'
       );
     });
+    it('handles ListingPageBook', () => {
+      const routes = routeConfiguration();
+      const location = {
+        pathname: '/l/some-slug-here/00000000-0000-0000-0000-000000000000/book',
+        search: '',
+        hash: '',
+      };
+      expect(canonicalRoutePath(routes, location)).toEqual(
+        '/l/00000000-0000-0000-0000-000000000000/book'
+      );
+    });
     it('handles ListingBasePage', () => {
       const routes = routeConfiguration();
       const location = {


### PR DESCRIPTION
We have a separate route to open the mobile booking modal in the listing page, but the page wasn't keeping it synced when the modal was closed and opened.

This PR removes the open state from the page state and keeps the tab state in the URL.