### PR TITLE
Add date/time format util

### DIFF
--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -22,3 +22,50 @@ export const nightsBetween = (startDate, endDate) => {
   }
   return nights;
 };
+
+/**
+ * Format the given date
+ *
+ * @param {Object} intl Intl object from react-intl
+ * @param {String} todayString translation for the current day
+ * @param {Date} d Date to be formatted
+ *
+ * @returns {String} formatted date
+ */
+export const formatDate = (intl, todayString, d) => {
+  const paramsValid = intl && d instanceof Date && typeof todayString === 'string';
+  if (!paramsValid) {
+    throw new Error(`Invalid params for formatDate: (${intl}, ${todayString}, ${d})`);
+  }
+  const now = moment(intl.now());
+  const formattedTime = intl.formatTime(d);
+  let formattedDate;
+
+  if (now.isSame(d, 'day')) {
+    // e.g. "Today, 9:10pm"
+    formattedDate = todayString;
+  } else if (now.isSame(d, 'week')) {
+    // e.g. "Wed, 8:00pm"
+    formattedDate = intl.formatDate(d, {
+      weekday: 'short',
+    });
+  } else if (now.isSame(d, 'year')) {
+    // e.g. "Aug 22, 7:40pm"
+    formattedDate = intl.formatDate(d, {
+      month: 'short',
+      day: 'numeric',
+    });
+  } else {
+    // e.g. "Jul 17 2016, 6:02pm"
+    const date = intl.formatDate(d, {
+      month: 'short',
+      day: 'numeric',
+    });
+    const year = intl.formatDate(d, {
+      year: 'numeric',
+    });
+    formattedDate = `${date} ${year}`;
+  }
+
+  return `${formattedDate}, ${formattedTime}`;
+};

--- a/src/util/dates.test.js
+++ b/src/util/dates.test.js
@@ -1,4 +1,5 @@
-import { nightsBetween } from './dates';
+import { fakeIntl } from './test-data';
+import { nightsBetween, formatDate } from './dates';
 
 describe('date utils', () => {
   describe('nightsBetween()', () => {
@@ -20,6 +21,22 @@ describe('date utils', () => {
       const start = new Date(2017, 0, 1);
       const end = new Date(2017, 0, 3);
       expect(nightsBetween(start, end)).toEqual(2);
+    });
+  });
+
+  describe('formatDate()', () => {
+    /*
+      NOTE: These are not really testing the formatting properly since
+      the fakeIntl object has to be used in the tests.
+     */
+
+    it('formats a date today', () => {
+      const d = new Date(Date.UTC(2017, 10, 23, 13, 51));
+      expect(formatDate(fakeIntl, 'Today', d)).toEqual('Today, 13:51');
+    });
+    it('formats a date', () => {
+      const d = new Date(Date.UTC(2017, 10, 22, 13, 51));
+      expect(formatDate(fakeIntl, 'Today', d)).toEqual('2017-11-22, 13:51');
     });
   });
 });

--- a/src/util/test-data.js
+++ b/src/util/test-data.js
@@ -154,7 +154,7 @@ export const fakeIntl = {
   formatPlural: d => d,
   formatRelative: d => d,
   formatTime: d => `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`,
-  now: d => d,
+  now: () => Date.UTC(2017, 10, 23, 12, 59),
 };
 
 const noop = () => null;


### PR DESCRIPTION
This PR adds a utility to format dates.

**Note:** proper tests require UI components since the utility needs the `intl` object. Those tests should be added when this util is used in the messaging components.

## Examples:

<img width="378" alt="screen shot 2017-11-06 at 16 23 06" src="https://user-images.githubusercontent.com/53923/32445775-846fd89a-c30f-11e7-9870-5db0e0610dae.png">
