### PR TITLE
Fix currency parsing with comma separator

### DIFF
--- a/src/components/CurrencyInputField/CurrencyInputField.js
+++ b/src/components/CurrencyInputField/CurrencyInputField.js
@@ -145,7 +145,9 @@ class CurrencyInputComponent extends Component {
       const isEmptyString = targetValue === '';
       const valueOrZero = isEmptyString ? '0' : targetValue;
 
-      const targetDecimalValue = isEmptyString ? null : new Decimal(targetValue);
+      const targetDecimalValue = isEmptyString
+        ? null
+        : new Decimal(ensureDotSeparator(targetValue));
 
       const isSafeValue =
         isEmptyString || (targetDecimalValue.isPositive() && isSafeNumber(targetDecimalValue));


### PR DESCRIPTION
Apparently Decimal used to accept the comma as a decimal separator (or
we had a bug/regression). This change wraps the raw value with the
ensureDotSeparator function that replaces the comma with the dot when
passing the value to Decimal.