### PR TITLE
Fix booking breakdown layout in sale page

### DIFF
--- a/src/components/SaleDetailsPanel/SaleDetailsPanel.css
+++ b/src/components/SaleDetailsPanel/SaleDetailsPanel.css
@@ -207,7 +207,7 @@
 }
 
 .breakdownDesktop {
-  margin: 0 48px 0 48px;
+  margin: 0 48px 50px 48px;
 }
 
 .feedContainer {
@@ -293,7 +293,7 @@
     box-shadow: none;
     width: auto;
     margin: 0 48px 48px 48px;
-    padding: 50px 0 0 0;
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
Fixes sale page booking breakdown layout from the accepted state onwards.

__Before:__
![before](https://user-images.githubusercontent.com/57473/33430347-e6886aa2-d5d8-11e7-8030-89e8e5439de0.png)


__After:__
![after](https://user-images.githubusercontent.com/57473/33430270-a739c08a-d5d8-11e7-9721-ab278c881d81.png)
