### PR TITLE
Add state param to reviews query

### DIFF
--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -77,7 +77,7 @@ export const showListing = listingId => (dispatch, getState, sdk) => {
 
 export const fetchReviews = listingId => (dispatch, getState, sdk) => {
   return sdk.reviews
-    .query({ listing_id: listingId, include: ['author', 'author.profileImage'] })
+    .query({ listing_id: listingId, state: 'public', include: ['author', 'author.profileImage'] })
     .then(response => {
       const entities = updatedEntities({}, response.data);
       const reviewIds = response.data.data.map(d => d.id);


### PR DESCRIPTION
Adds a `state: 'public'` param to listing page reviews query to fetch only public reviews.