### PR TITLE
Fix contact link text jump

### DIFF
--- a/src/containers/ListingPage/ListingPage.css
+++ b/src/containers/ListingPage/ListingPage.css
@@ -337,6 +337,7 @@
 
 .contactLink {
   @apply --marketplaceH4FontStyles;
+  margin: 0;
 }
 
 .descriptionContainer {


### PR DESCRIPTION
When the contact link is hidden in the server rendered HTML, the text
jumps when the link is rendered in the client with the margins.