### PR TITLE
Add Apache-2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2018 Sharetribe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ The `master` branch is automatically deployed to Heroku. If you want to deploy a
 setup the `sharetribe-starter-app` Heroku app and push the feature branch:
 
     git push heroku my-feature-branch:master
+
+## License
+
+This project is licensed under the terms of the Apache-2.0 license.
+
+See [LICENSE](LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "version": "0.2.0",
   "private": true,
+  "license": "Apache-2.0",
   "dependencies": {
     "array-includes": "^3.0.3",
     "array.prototype.find": "^2.0.4",


### PR DESCRIPTION
This PR adds the [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0) license to the repository.