### PR TITLE
Disable example custom attributes by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 .DS_Store
 .env
 npm-debug.log
+/.env.development.local

--- a/src/config.js
+++ b/src/config.js
@@ -228,13 +228,19 @@ const stripeSupportedCountries = [
 //      },
 //    },
 //  }
-const customAttributes = {
+const exampleCustomAttributes = {
   category: {
     select: 'single', // possible values: 'single' (only type supported atm.)
     type: 'string',
     values: ['road', 'mountain', 'track', 'other'],
   },
 };
+
+// To use the example custom attributes, set the
+// REACT_APP_USE_EXAMPLE_CUSTOM_ATTRIBUTES variable to `true` in the
+// gitignored `.env.development.local` file
+const useExampleCustomAttributes = process.env.REACT_APP_USE_EXAMPLE_CUSTOM_ATTRIBUTES === 'true';
+const customAttributes = useExampleCustomAttributes ? exampleCustomAttributes : {};
 
 // Address information is used in SEO schema for Organization (http://schema.org/PostalAddress)
 const addressCountry = 'FI';

--- a/src/containers/EditListingDescriptionForm/__snapshots__/EditListingDescriptionForm.test.js.snap
+++ b/src/containers/EditListingDescriptionForm/__snapshots__/EditListingDescriptionForm.test.js.snap
@@ -54,52 +54,6 @@ exports[`EditListingDescriptionForm matches snapshot 1`] = `
       value=""
     />
   </div>
-  <div
-    className=""
-  >
-    <label
-      htmlFor="fakeTestForm.category"
-    >
-      FieldCustomAttributeSelect.category.label
-    </label>
-    <select
-      className=""
-      id="fakeTestForm.category"
-      name="category"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onDragStart={[Function]}
-      onDrop={[Function]}
-      onFocus={[Function]}
-      value=""
-    >
-      <option
-        value=""
-      >
-        FieldCustomAttributeSelect.category.placeholder
-      </option>
-      <option
-        value="road"
-      >
-        FieldCustomAttributeSelect.category.option.road
-      </option>
-      <option
-        value="mountain"
-      >
-        FieldCustomAttributeSelect.category.option.mountain
-      </option>
-      <option
-        value="track"
-      >
-        FieldCustomAttributeSelect.category.option.track
-      </option>
-      <option
-        value="other"
-      >
-        FieldCustomAttributeSelect.category.option.other
-      </option>
-    </select>
-  </div>
   <button
     className=""
     disabled={true}


### PR DESCRIPTION
By default the starter app should not expect any custom attributes defined. This PR makes those disabled by default, but enables taking them into use by setting the `REACT_APP_USE_EXAMPLE_CUSTOM_ATTRIBUTES` env var to `true`.
  