### PR TITLE
Refactor propTypes module

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -6,7 +6,7 @@ import { Switch, Route, withRouter } from 'react-router-dom';
 import { NotFoundPage } from './containers';
 import { NamedRedirect } from './components';
 import { locationChanged } from './ducks/Routing.duck';
-import * as propTypes from './util/propTypes';
+import { propTypes } from './util/types';
 import * as log from './util/log';
 import { canonicalRoutePath } from './util/routes';
 import routeConfiguration from './routeConfiguration';

--- a/src/components/ActivityFeed/ActivityFeed.example.js
+++ b/src/components/ActivityFeed/ActivityFeed.example.js
@@ -8,7 +8,19 @@ import {
   createTxTransition,
   createReview,
 } from '../../util/test-data';
-import * as propTypes from '../../util/propTypes';
+import {
+  TX_TRANSITION_ACCEPT,
+  TX_TRANSITION_ACTOR_CUSTOMER,
+  TX_TRANSITION_ACTOR_PROVIDER,
+  TX_TRANSITION_AUTO_COMPLETE_WITHOUT_REVIEWS,
+  TX_TRANSITION_DECLINE,
+  TX_TRANSITION_MARK_DELIVERED,
+  TX_TRANSITION_PREAUTHORIZE,
+  TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
+  TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
+  TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
+  TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
+} from '../../util/types';
 import ActivityFeed from './ActivityFeed';
 
 const noop = () => null;
@@ -70,19 +82,19 @@ export const WithTransitions = {
       transitions: [
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 8, 10)),
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_PREAUTHORIZE,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 8, 12)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_ACCEPT,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_ACCEPT,
         }),
         // this should not be visible in the feed
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 16, 8, 12)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_AUTO_COMPLETE_WITHOUT_REVIEWS,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_AUTO_COMPLETE_WITHOUT_REVIEWS,
         }),
       ],
     }),
@@ -103,37 +115,37 @@ export const WithMessagesTransitionsAndReviews = {
       customer: createUser('user1'),
       provider: createUser('user2'),
       listing: createListing('Listing'),
-      lastTransition: propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
+      lastTransition: TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
       transitions: [
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 8, 10)),
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_PREAUTHORIZE,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 8, 12)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_ACCEPT,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_ACCEPT,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 10, 33)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_DECLINE,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_DECLINE,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 10, 34)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_MARK_DELIVERED,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_MARK_DELIVERED,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 11, 34)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 12, 34)),
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
         }),
       ],
       reviews: [
@@ -199,17 +211,17 @@ export const WithAReviewFromBothUsers = {
           { author: createUser('user2'), subject: createUser('user1') }
         ),
       ],
-      lastTransition: propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
+      lastTransition: TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
       transitions: [
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 9, 8, 10)),
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
         }),
         createTxTransition({
           at: new Date(Date.UTC(2017, 10, 10, 8, 10)),
-          by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-          transition: propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
+          by: TX_TRANSITION_ACTOR_PROVIDER,
+          transition: TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
         }),
       ],
     }),
@@ -244,21 +256,21 @@ class PagedFeed extends Component {
 
     const trans1 = createTxTransition({
       at: dates[0],
-      by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-      transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      by: TX_TRANSITION_ACTOR_CUSTOMER,
+      transition: TX_TRANSITION_PREAUTHORIZE,
     });
     const trans2 = createTxTransition({
       at: dates[2],
-      by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-      transition: propTypes.TX_TRANSITION_ACCEPT,
+      by: TX_TRANSITION_ACTOR_PROVIDER,
+      transition: TX_TRANSITION_ACCEPT,
     });
 
     // Last transition timestamp is interleaved between the last two
     // messages.
     const trans3 = createTxTransition({
       at: dates[5],
-      by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-      transition: propTypes.TX_TRANSITION_MARK_DELIVERED,
+      by: TX_TRANSITION_ACTOR_CUSTOMER,
+      transition: TX_TRANSITION_MARK_DELIVERED,
     });
 
     // First message timestamp is interleaved between the first two
@@ -271,7 +283,7 @@ class PagedFeed extends Component {
 
     const transaction = createTransaction({
       id: 'tx1',
-      lastTransition: propTypes.TX_TRANSITION_MARK_DELIVERED,
+      lastTransition: TX_TRANSITION_MARK_DELIVERED,
       lastTransitionedAt: dates[5],
       transitions: [trans1, trans2, trans3],
       listing: createListing('listing'),

--- a/src/components/ActivityFeed/ActivityFeed.js
+++ b/src/components/ActivityFeed/ActivityFeed.js
@@ -6,7 +6,23 @@ import classNames from 'classnames';
 import { Avatar, InlineTextButton, ReviewRating } from '../../components';
 import { formatDate } from '../../util/dates';
 import { ensureTransaction, ensureUser, ensureListing, userDisplayName } from '../../util/data';
-import * as propTypes from '../../util/propTypes';
+import {
+  TX_TRANSITION_ACCEPT,
+  TX_TRANSITION_ACTOR_CUSTOMER,
+  TX_TRANSITION_ACTOR_PROVIDER,
+  TX_TRANSITION_AUTO_DECLINE,
+  TX_TRANSITION_CANCEL,
+  TX_TRANSITION_DECLINE,
+  TX_TRANSITION_MARK_DELIVERED,
+  TX_TRANSITION_PREAUTHORIZE,
+  TX_TRANSITION_PREAUTHORIZE_ENQUIRY,
+  TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
+  TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
+  TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
+  TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
+  areReviewsCompleted,
+  propTypes,
+} from '../../util/types';
 import * as log from '../../util/log';
 
 import css from './ActivityFeed.css';
@@ -71,17 +87,17 @@ Review.propTypes = {
 // should be rendered in he ActivityFeed
 const shouldRenderTransition = transition => {
   return [
-    propTypes.TX_TRANSITION_PREAUTHORIZE,
-    propTypes.TX_TRANSITION_PREAUTHORIZE_ENQUIRY,
-    propTypes.TX_TRANSITION_ACCEPT,
-    propTypes.TX_TRANSITION_DECLINE,
-    propTypes.TX_TRANSITION_AUTO_DECLINE,
-    propTypes.TX_TRANSITION_CANCEL,
-    propTypes.TX_TRANSITION_MARK_DELIVERED,
-    propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
-    propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
-    propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
-    propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
+    TX_TRANSITION_PREAUTHORIZE,
+    TX_TRANSITION_PREAUTHORIZE_ENQUIRY,
+    TX_TRANSITION_ACCEPT,
+    TX_TRANSITION_DECLINE,
+    TX_TRANSITION_AUTO_DECLINE,
+    TX_TRANSITION_CANCEL,
+    TX_TRANSITION_MARK_DELIVERED,
+    TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
+    TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
+    TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
+    TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
   ].includes(transition);
 };
 
@@ -89,20 +105,20 @@ const shouldRenderTransition = transition => {
 // given tx transition.
 const isReviewTransition = transition => {
   return [
-    propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
-    propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
-    propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
-    propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
+    TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST,
+    TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST,
+    TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND,
+    TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND,
   ].includes(transition);
 };
 
 const hasUserLeftAReviewFirst = (userRole, lastTransition) => {
   return (
-    (lastTransition === propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST &&
-      userRole === propTypes.TX_TRANSITION_ACTOR_CUSTOMER) ||
-    (lastTransition === propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST &&
-      userRole === propTypes.TX_TRANSITION_ACTOR_PROVIDER) ||
-    propTypes.areReviewsCompleted(lastTransition)
+    (lastTransition === TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST &&
+      userRole === TX_TRANSITION_ACTOR_CUSTOMER) ||
+    (lastTransition === TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST &&
+      userRole === TX_TRANSITION_ACTOR_PROVIDER) ||
+    areReviewsCompleted(lastTransition)
   );
 };
 
@@ -118,11 +134,11 @@ const resolveTransitionMessage = (
   const isOwnTransition = transition.by === ownRole;
   const currentTransition = transition.transition;
   const displayName = otherUsersName;
-  const deliveredState = lastTransition === propTypes.TX_TRANSITION_MARK_DELIVERED;
+  const deliveredState = lastTransition === TX_TRANSITION_MARK_DELIVERED;
 
   switch (currentTransition) {
-    case propTypes.TX_TRANSITION_PREAUTHORIZE:
-    case propTypes.TX_TRANSITION_PREAUTHORIZE_ENQUIRY:
+    case TX_TRANSITION_PREAUTHORIZE:
+    case TX_TRANSITION_PREAUTHORIZE_ENQUIRY:
       return isOwnTransition ? (
         <FormattedMessage id="ActivityFeed.ownTransitionRequest" values={{ listingTitle }} />
       ) : (
@@ -131,27 +147,27 @@ const resolveTransitionMessage = (
           values={{ displayName, listingTitle }}
         />
       );
-    case propTypes.TX_TRANSITION_ACCEPT:
+    case TX_TRANSITION_ACCEPT:
       return isOwnTransition ? (
         <FormattedMessage id="ActivityFeed.ownTransitionAccept" />
       ) : (
         <FormattedMessage id="ActivityFeed.transitionAccept" values={{ displayName }} />
       );
-    case propTypes.TX_TRANSITION_DECLINE:
+    case TX_TRANSITION_DECLINE:
       return isOwnTransition ? (
         <FormattedMessage id="ActivityFeed.ownTransitionDecline" />
       ) : (
         <FormattedMessage id="ActivityFeed.transitionDecline" />
       );
-    case propTypes.TX_TRANSITION_AUTO_DECLINE:
-      return ownRole === propTypes.TX_TRANSITION_ACTOR_PROVIDER ? (
+    case TX_TRANSITION_AUTO_DECLINE:
+      return ownRole === TX_TRANSITION_ACTOR_PROVIDER ? (
         <FormattedMessage id="ActivityFeed.ownTransitionAutoDecline" />
       ) : (
         <FormattedMessage id="ActivityFeed.transitionAutoDecline" values={{ displayName }} />
       );
-    case propTypes.TX_TRANSITION_CANCEL:
+    case TX_TRANSITION_CANCEL:
       return <FormattedMessage id="ActivityFeed.transitionCancel" />;
-    case propTypes.TX_TRANSITION_MARK_DELIVERED:
+    case TX_TRANSITION_MARK_DELIVERED:
       // Show the leave a review link if the state is delivered or
       // if current user is not the first to leave a review
       const reviewLink =
@@ -162,8 +178,8 @@ const resolveTransitionMessage = (
         ) : null;
 
       return <FormattedMessage id="ActivityFeed.transitionComplete" values={{ reviewLink }} />;
-    case propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST:
-    case propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST:
+    case TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST:
+    case TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST:
       if (isOwnTransition) {
         return <FormattedMessage id="ActivityFeed.ownTransitionReview" values={{ displayName }} />;
       } else {
@@ -181,8 +197,8 @@ const resolveTransitionMessage = (
           />
         );
       }
-    case propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND:
-    case propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND:
+    case TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND:
+    case TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND:
       if (isOwnTransition) {
         return <FormattedMessage id="ActivityFeed.ownTransitionReview" values={{ displayName }} />;
       } else {
@@ -223,14 +239,14 @@ const Transition = props => {
 
   const ownRole =
     currentUser.id.uuid === customer.id.uuid
-      ? propTypes.TX_TRANSITION_ACTOR_CUSTOMER
-      : propTypes.TX_TRANSITION_ACTOR_PROVIDER;
+      ? TX_TRANSITION_ACTOR_CUSTOMER
+      : TX_TRANSITION_ACTOR_PROVIDER;
 
   const bannedUserDisplayName = intl.formatMessage({
     id: 'ActivityFeed.bannedUserDisplayName',
   });
   const otherUsersName =
-    ownRole === propTypes.TX_TRANSITION_ACTOR_CUSTOMER
+    ownRole === TX_TRANSITION_ACTOR_CUSTOMER
       ? userDisplayName(provider, bannedUserDisplayName)
       : userDisplayName(customer, bannedUserDisplayName);
 
@@ -247,13 +263,13 @@ const Transition = props => {
 
   let reviewComponent = null;
 
-  if (isReviewTransition(currentTransition) && propTypes.areReviewsCompleted(lastTransition)) {
+  if (isReviewTransition(currentTransition) && areReviewsCompleted(lastTransition)) {
     const customerReview =
-      currentTransition === propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST ||
-      currentTransition === propTypes.TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND;
+      currentTransition === TX_TRANSITION_REVIEW_BY_CUSTOMER_FIRST ||
+      currentTransition === TX_TRANSITION_REVIEW_BY_CUSTOMER_SECOND;
     const providerReview =
-      currentTransition === propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST ||
-      currentTransition === propTypes.TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND;
+      currentTransition === TX_TRANSITION_REVIEW_BY_PROVIDER_FIRST ||
+      currentTransition === TX_TRANSITION_REVIEW_BY_PROVIDER_SECOND;
     if (customerReview) {
       const review = reviewByAuthorId(currentTransaction, customer.id);
       reviewComponent = (

--- a/src/components/AddImages/AddImages.example.js
+++ b/src/components/AddImages/AddImages.example.js
@@ -2,9 +2,11 @@
 import React, { Component } from 'react';
 import { findIndex, uniqueId } from 'lodash';
 import { arrayMove } from 'react-sortable-hoc';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import AddImages from './AddImages';
 import css from './AddImages.example.css';
+
+const { UUID } = sdkTypes;
 
 const getId = () => {
   return uniqueId();
@@ -33,7 +35,6 @@ class AddImagesTest extends Component {
     // Fake image uploaded state: show image thumbnail
     setTimeout(() => {
       this.setState(prevState => {
-        const { UUID } = types;
         const images = prevState.images;
         const imageIndex = findIndex(images, i => i.id === fileId);
         const updatedImage = { ...imageData, imageId: new UUID(fileId) };

--- a/src/components/Avatar/Avatar.example.js
+++ b/src/components/Avatar/Avatar.example.js
@@ -1,8 +1,8 @@
 import Avatar, { AvatarMedium, AvatarLarge } from './Avatar';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { fakeIntl } from '../../util/test-data';
 
-const { UUID } = types;
+const { UUID } = sdkTypes;
 
 const bannedUser = {
   id: new UUID('banned-user'),

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureUser, userDisplayName, userAbbreviatedName } from '../../util/data';
 import { ResponsiveImage, IconBannedUser, NamedLink } from '../../components/';
 

--- a/src/components/BookingBreakdown/BookingBreakdown.example.js
+++ b/src/components/BookingBreakdown/BookingBreakdown.example.js
@@ -1,10 +1,20 @@
 import Decimal from 'decimal.js';
-import { types } from '../../util/sdkLoader';
-import * as propTypes from '../../util/propTypes';
+import { types as sdkTypes } from '../../util/sdkLoader';
+import {
+  LINE_ITEM_DAY,
+  LINE_ITEM_NIGHT,
+  TX_TRANSITION_ACCEPT,
+  TX_TRANSITION_ACTOR_CUSTOMER,
+  TX_TRANSITION_AUTO_DECLINE,
+  TX_TRANSITION_CANCEL,
+  TX_TRANSITION_DECLINE,
+  TX_TRANSITION_MARK_DELIVERED,
+  TX_TRANSITION_PREAUTHORIZE,
+} from '../../util/types';
 import config from '../../config';
 import BookingBreakdown from './BookingBreakdown';
 
-const { UUID, Money } = types;
+const { UUID, Money } = sdkTypes;
 
 const CURRENCY = config.currency;
 
@@ -24,12 +34,12 @@ const exampleTransaction = params => {
     attributes: {
       createdAt: created,
       lastTransitionedAt: created,
-      lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      lastTransition: TX_TRANSITION_PREAUTHORIZE,
       transitions: [
         {
           at: created,
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_PREAUTHORIZE,
         },
       ],
 
@@ -43,7 +53,7 @@ export const Checkout = {
   component: BookingBreakdown,
   props: {
     userRole: 'customer',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
       payinTotal: new Money(9000, CURRENCY),
       payoutTotal: new Money(9000, CURRENCY),
@@ -69,7 +79,7 @@ export const CustomerOrder = {
   component: BookingBreakdown,
   props: {
     userRole: 'customer',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
       payinTotal: new Money(9000, CURRENCY),
       payoutTotal: new Money(9000, CURRENCY),
@@ -95,7 +105,7 @@ export const ProviderSale = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
       payinTotal: new Money(9000, CURRENCY),
       payoutTotal: new Money(7000, CURRENCY),
@@ -128,7 +138,7 @@ export const ProviderSaleZeroCommission = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
       payinTotal: new Money(9000, CURRENCY),
       payoutTotal: new Money(9000, CURRENCY),
@@ -161,7 +171,7 @@ export const ProviderSaleSingleNight = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(2500, CURRENCY),
@@ -194,9 +204,9 @@ export const ProviderSalePreauthorized = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
-      lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      lastTransition: TX_TRANSITION_PREAUTHORIZE,
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(2500, CURRENCY),
       lineItems: [
@@ -228,9 +238,9 @@ export const ProviderSaleAccepted = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
-      lastTransition: propTypes.TX_TRANSITION_ACCEPT,
+      lastTransition: TX_TRANSITION_ACCEPT,
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(2500, CURRENCY),
       lineItems: [
@@ -262,9 +272,9 @@ export const ProviderSaleDeclined = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
-      lastTransition: propTypes.TX_TRANSITION_DECLINE,
+      lastTransition: TX_TRANSITION_DECLINE,
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(2500, CURRENCY),
       lineItems: [
@@ -296,9 +306,9 @@ export const ProviderSaleAutoDeclined = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
-      lastTransition: propTypes.TX_TRANSITION_AUTO_DECLINE,
+      lastTransition: TX_TRANSITION_AUTO_DECLINE,
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(2500, CURRENCY),
       lineItems: [
@@ -330,9 +340,9 @@ export const ProviderSaleDelivered = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
-      lastTransition: propTypes.TX_TRANSITION_MARK_DELIVERED,
+      lastTransition: TX_TRANSITION_MARK_DELIVERED,
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(2500, CURRENCY),
       lineItems: [
@@ -364,9 +374,9 @@ export const ProviderSaleCanceled = {
   component: BookingBreakdown,
   props: {
     userRole: 'provider',
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     transaction: exampleTransaction({
-      lastTransition: propTypes.TX_TRANSITION_CANCEL,
+      lastTransition: TX_TRANSITION_CANCEL,
       payinTotal: new Money(0, CURRENCY),
       payoutTotal: new Money(0, CURRENCY),
       lineItems: [
@@ -415,7 +425,7 @@ export const SingleDay = {
   component: BookingBreakdown,
   props: {
     userRole: 'customer',
-    unitType: propTypes.LINE_ITEM_DAY,
+    unitType: LINE_ITEM_DAY,
     transaction: exampleTransaction({
       payinTotal: new Money(4500, CURRENCY),
       payoutTotal: new Money(4500, CURRENCY),
@@ -441,7 +451,7 @@ export const MultipleDays = {
   component: BookingBreakdown,
   props: {
     userRole: 'customer',
-    unitType: propTypes.LINE_ITEM_DAY,
+    unitType: LINE_ITEM_DAY,
     transaction: exampleTransaction({
       payinTotal: new Money(9000, CURRENCY),
       payoutTotal: new Money(9000, CURRENCY),

--- a/src/components/BookingBreakdown/BookingBreakdown.js
+++ b/src/components/BookingBreakdown/BookingBreakdown.js
@@ -7,14 +7,21 @@ import { bool, oneOf, string } from 'prop-types';
 import { FormattedMessage, FormattedHTMLMessage, intlShape, injectIntl } from 'react-intl';
 import moment from 'moment';
 import classNames from 'classnames';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { formatMoney } from '../../util/currency';
-import * as propTypes from '../../util/propTypes';
+import {
+  LINE_ITEM_NIGHT,
+  LINE_ITEM_PROVIDER_COMMISSION,
+  txIsCanceled,
+  txIsDeclinedOrAutodeclined,
+  txIsDelivered,
+  propTypes,
+} from '../../util/types';
 import { daysBetween } from '../../util/dates';
 
 import css from './BookingBreakdown.css';
 
-const { Money } = types;
+const { Money } = sdkTypes;
 
 // Validate the assumption that the commission exists and the amount
 // is zero or negative.
@@ -28,7 +35,7 @@ const isValidCommission = commissionLineItem => {
 
 const UnitPriceItem = props => {
   const { transaction, unitType, intl } = props;
-  const isNightly = unitType === propTypes.LINE_ITEM_NIGHT;
+  const isNightly = unitType === LINE_ITEM_NIGHT;
   const unitPurchase = transaction.attributes.lineItems.find(
     item => item.code === unitType && !item.reversal
   );
@@ -56,7 +63,7 @@ const UnitsItem = props => {
   const { transaction, booking, unitType, intl } = props;
 
   const { start: startDate, end: endDateRaw } = booking.attributes;
-  const isNightly = unitType === propTypes.LINE_ITEM_NIGHT;
+  const isNightly = unitType === LINE_ITEM_NIGHT;
   const isSingleDay = !isNightly && daysBetween(startDate, endDateRaw) === 1;
 
   const endDay = isNightly ? endDateRaw : moment(endDateRaw).subtract(1, 'days');
@@ -142,10 +149,10 @@ const CommissionItemMaybe = props => {
   const { transaction, isProvider, intl } = props;
 
   const providerCommissionLineItem = transaction.attributes.lineItems.find(
-    item => item.code === propTypes.LINE_ITEM_PROVIDER_COMMISSION && !item.reversal
+    item => item.code === LINE_ITEM_PROVIDER_COMMISSION && !item.reversal
   );
   const commissionRefund = transaction.attributes.lineItems.find(
-    item => item.code === propTypes.LINE_ITEM_PROVIDER_COMMISSION && item.reversal
+    item => item.code === LINE_ITEM_PROVIDER_COMMISSION && item.reversal
   );
 
   // If commission is passed it will be shown as a fee already reduces from the total price
@@ -209,11 +216,11 @@ export const BookingBreakdownComponent = props => {
   const classes = classNames(rootClassName || css.root, className);
 
   let providerTotalMessageId = 'BookingBreakdown.providerTotalDefault';
-  if (propTypes.txIsDelivered(transaction)) {
+  if (txIsDelivered(transaction)) {
     providerTotalMessageId = 'BookingBreakdown.providerTotalDelivered';
-  } else if (propTypes.txIsDeclinedOrAutodeclined(transaction)) {
+  } else if (txIsDeclinedOrAutodeclined(transaction)) {
     providerTotalMessageId = 'BookingBreakdown.providerTotalDeclined';
-  } else if (propTypes.txIsCanceled(transaction)) {
+  } else if (txIsCanceled(transaction)) {
     providerTotalMessageId = 'BookingBreakdown.providerTotalCanceled';
   }
 

--- a/src/components/BookingBreakdown/BookingBreakdown.test.js
+++ b/src/components/BookingBreakdown/BookingBreakdown.test.js
@@ -2,11 +2,16 @@ import React from 'react';
 import Decimal from 'decimal.js';
 import { fakeIntl, createBooking } from '../../util/test-data';
 import { renderDeep } from '../../util/test-helpers';
-import { types } from '../../util/sdkLoader';
-import * as propTypes from '../../util/propTypes';
+import { types as sdkTypes } from '../../util/sdkLoader';
+import {
+  LINE_ITEM_NIGHT,
+  TX_TRANSITION_ACTOR_CUSTOMER,
+  TX_TRANSITION_CANCEL,
+  TX_TRANSITION_PREAUTHORIZE,
+} from '../../util/types';
 import { BookingBreakdownComponent } from './BookingBreakdown';
 
-const { UUID, Money } = types;
+const { UUID, Money } = sdkTypes;
 
 const exampleTransaction = params => {
   const created = new Date(Date.UTC(2017, 1, 1));
@@ -16,12 +21,12 @@ const exampleTransaction = params => {
     attributes: {
       createdAt: created,
       lastTransitionedAt: created,
-      lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      lastTransition: TX_TRANSITION_PREAUTHORIZE,
       transitions: [
         {
           at: created,
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_PREAUTHORIZE,
         },
       ],
 
@@ -36,7 +41,7 @@ describe('BookingBreakdown', () => {
     const tree = renderDeep(
       <BookingBreakdownComponent
         userRole="customer"
-        unitType={propTypes.LINE_ITEM_NIGHT}
+        unitType={LINE_ITEM_NIGHT}
         transaction={exampleTransaction({
           payinTotal: new Money(2000, 'USD'),
           payoutTotal: new Money(2000, 'USD'),
@@ -65,7 +70,7 @@ describe('BookingBreakdown', () => {
     const tree = renderDeep(
       <BookingBreakdownComponent
         userRole="customer"
-        unitType={propTypes.LINE_ITEM_NIGHT}
+        unitType={LINE_ITEM_NIGHT}
         transaction={exampleTransaction({
           payinTotal: new Money(2000, 'USD'),
           payoutTotal: new Money(2000, 'USD'),
@@ -94,7 +99,7 @@ describe('BookingBreakdown', () => {
     const tree = renderDeep(
       <BookingBreakdownComponent
         userRole="provider"
-        unitType={propTypes.LINE_ITEM_NIGHT}
+        unitType={LINE_ITEM_NIGHT}
         transaction={exampleTransaction({
           payinTotal: new Money(2000, 'USD'),
           payoutTotal: new Money(1800, 'USD'),
@@ -129,9 +134,9 @@ describe('BookingBreakdown', () => {
     const tree = renderDeep(
       <BookingBreakdownComponent
         userRole="provider"
-        unitType={propTypes.LINE_ITEM_NIGHT}
+        unitType={LINE_ITEM_NIGHT}
         transaction={exampleTransaction({
-          lastTransition: propTypes.TX_TRANSITION_CANCEL,
+          lastTransition: TX_TRANSITION_CANCEL,
           payinTotal: new Money(0, 'USD'),
           payoutTotal: new Money(0, 'USD'),
           lineItems: [

--- a/src/components/CurrencyInputField/CurrencyInputField.js
+++ b/src/components/CurrencyInputField/CurrencyInputField.js
@@ -10,7 +10,7 @@ import { Field } from 'redux-form';
 import classNames from 'classnames';
 import Decimal from 'decimal.js';
 import { ValidationError } from '../../components';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import {
   isSafeNumber,
   unitDivisor,
@@ -20,10 +20,12 @@ import {
   ensureSeparator,
   truncateToSubUnitPrecision,
 } from '../../util/currency';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import * as log from '../../util/log';
 
 import css from './CurrencyInputField.css';
+
+const { Money } = sdkTypes;
 
 const allowedInputProps = allProps => {
   // Strip away props that are not passed to input element (or are overwritten)
@@ -38,7 +40,7 @@ const getPrice = (unformattedValue, currencyConfig) => {
   try {
     return isEmptyString
       ? null
-      : new types.Money(
+      : new Money(
           convertUnitToSubUnit(unformattedValue, unitDivisor(currencyConfig.currency)),
           currencyConfig.currency
         );
@@ -51,7 +53,7 @@ class CurrencyInputComponent extends Component {
   constructor(props) {
     super(props);
     const { currencyConfig, defaultValue, input, intl } = props;
-    const initialValueIsMoney = input.value instanceof types.Money;
+    const initialValueIsMoney = input.value instanceof Money;
 
     if (initialValueIsMoney && input.value.currency !== currencyConfig.currency) {
       const e = new Error('Value currency different from marketplace currency');

--- a/src/components/DateRangeInputField/DateRangeInput.js
+++ b/src/components/DateRangeInputField/DateRangeInput.js
@@ -16,7 +16,7 @@ import { intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 import moment from 'moment';
 import { START_DATE, END_DATE } from '../../util/dates';
-import * as propTypes from '../../util/propTypes';
+import { LINE_ITEM_DAY, propTypes } from '../../util/types';
 import config from '../../config';
 
 import NextMonthIcon from './NextMonthIcon';
@@ -37,7 +37,7 @@ const BLUR_TIMEOUT = 100;
 
 const apiEndDateToPickerDate = (unitType, endDate) => {
   const isValid = endDate instanceof Date;
-  const isDaily = unitType === propTypes.LINE_ITEM_DAY;
+  const isDaily = unitType === LINE_ITEM_DAY;
 
   if (!isValid) {
     return null;
@@ -52,7 +52,7 @@ const apiEndDateToPickerDate = (unitType, endDate) => {
 
 const pickerEndDateToApiDate = (unitType, endDate) => {
   const isValid = endDate instanceof moment;
-  const isDaily = unitType === propTypes.LINE_ITEM_DAY;
+  const isDaily = unitType === LINE_ITEM_DAY;
 
   if (!isValid) {
     return null;
@@ -217,7 +217,7 @@ class DateRangeInputComponent extends Component {
     } = this.props;
     /* eslint-enable no-unused-vars */
 
-    const isDaily = unitType === propTypes.LINE_ITEM_DAY;
+    const isDaily = unitType === LINE_ITEM_DAY;
     const initialStartMoment = initialDates ? moment(initialDates.startDate) : null;
     const initialEndMoment = initialDates ? moment(initialDates.endDate) : null;
     const startDate =

--- a/src/components/DateRangeInputField/DateRangeInputField.example.js
+++ b/src/components/DateRangeInputField/DateRangeInputField.example.js
@@ -4,7 +4,7 @@ import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import moment from 'moment';
 import { Button } from '../../components';
 import { required, bookingDatesRequired } from '../../util/validators';
-import * as propTypes from '../../util/propTypes';
+import { LINE_ITEM_NIGHT } from '../../util/types';
 import DateRangeInputField from './DateRangeInputField';
 
 const FormComponent = props => {
@@ -33,7 +33,7 @@ export const Empty = {
   props: {
     dateInputProps: {
       name: 'bookingDates',
-      unitType: propTypes.LINE_ITEM_NIGHT,
+      unitType: LINE_ITEM_NIGHT,
       startDateId: `${defaultFormName}.bookingStartDate`,
       startDateLabel: 'Start date',
       startDatePlaceholderText: moment().format('ddd, MMMM D'),

--- a/src/components/DateRangeInputField/DateRangeInputField.js
+++ b/src/components/DateRangeInputField/DateRangeInputField.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import classNames from 'classnames';
 import { START_DATE, END_DATE } from '../../util/dates';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ValidationError } from '../../components';
 
 import DateRangeInput from './DateRangeInput';

--- a/src/components/DateRangeInputField/DateRangeInputField.test.js
+++ b/src/components/DateRangeInputField/DateRangeInputField.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderDeep } from '../../util/test-helpers';
-import * as propTypes from '../../util/propTypes';
+import { LINE_ITEM_NIGHT } from '../../util/types';
 import { DateRangeInput } from './DateRangeInputField';
 
 const noop = () => null;
@@ -8,7 +8,7 @@ const noop = () => null;
 describe('DateRangeInput', () => {
   it('matches snapshot', () => {
     const props = {
-      unitType: propTypes.LINE_ITEM_NIGHT,
+      unitType: LINE_ITEM_NIGHT,
       name: 'bookingDates',
       onBlur: noop,
       onChange: noop,

--- a/src/components/EditListingPhotosPanel/EditListingPhotosPanel.js
+++ b/src/components/EditListingPhotosPanel/EditListingPhotosPanel.js
@@ -7,7 +7,7 @@ import { createSlug } from '../../util/urlHelpers';
 import { EditListingPhotosForm, PayoutDetailsForm } from '../../containers';
 import { ensureListing } from '../../util/data';
 import { Modal, NamedLink } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './EditListingPhotosPanel.css';
 

--- a/src/components/EditListingPricingPanel/EditListingPricingPanel.js
+++ b/src/components/EditListingPricingPanel/EditListingPricingPanel.js
@@ -6,10 +6,12 @@ import { createSlug } from '../../util/urlHelpers';
 import { NamedLink } from '../../components';
 import { EditListingPricingForm } from '../../containers';
 import { ensureListing } from '../../util/data';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import config from '../../config';
 
 import css from './EditListingPricingPanel.css';
+
+const { Money } = sdkTypes;
 
 const EditListingPricingPanel = props => {
   const {
@@ -42,8 +44,7 @@ const EditListingPricingPanel = props => {
     <FormattedMessage id="EditListingPricingPanel.createListingTitle" />
   );
 
-  const priceCurrencyValid =
-    price instanceof types.Money ? price.currency === config.currency : true;
+  const priceCurrencyValid = price instanceof Money ? price.currency === config.currency : true;
   const form = priceCurrencyValid ? (
     <EditListingPricingForm
       className={css.form}

--- a/src/components/EditListingWizard/EditListingWizard.js
+++ b/src/components/EditListingWizard/EditListingWizard.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import routeConfiguration from '../../routeConfiguration';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureListing } from '../../util/data';
 import { createResourceLocatorString } from '../../util/routes';
 import {

--- a/src/components/ImageCarousel/ImageCarousel.js
+++ b/src/components/ImageCarousel/ImageCarousel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import { ResponsiveImage } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './ImageCarousel.css';
 

--- a/src/components/ListingCard/ListingCard.js
+++ b/src/components/ListingCard/ListingCard.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 import { NamedLink, ResponsiveImage } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { formatMoney } from '../../util/currency';
 import { ensureListing, ensureUser } from '../../util/data';
 import { createSlug } from '../../util/urlHelpers';

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInput.example.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInput.example.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Field, reduxForm, propTypes as formPropTypes } from 'redux-form';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { Button } from '../../components';
 import LocationAutocompleteInput from './LocationAutocompleteInput';
 

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInput.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import { debounce } from 'lodash';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { getPlacePredictions, getPlaceDetails } from '../../util/googleMaps';
 import { ValidationError } from '../../components';
 

--- a/src/components/ManageListingCard/ManageListingCard.js
+++ b/src/components/ManageListingCard/ManageListingCard.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 import routeConfiguration from '../../routeConfiguration';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { formatMoney } from '../../util/currency';
 import { ensureListing } from '../../util/data';
 import { createSlug } from '../../util/urlHelpers';

--- a/src/components/Map/Map.example.js
+++ b/src/components/Map/Map.example.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import Map from './Map';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 
-const { LatLng } = types;
+const { LatLng } = sdkTypes;
 
 export const Empty = {
   component: props => (

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import CustomMarker from './images/marker-32x32.png';
 import css from './Map.css';

--- a/src/components/PaginationLinks/PaginationLinks.js
+++ b/src/components/PaginationLinks/PaginationLinks.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { range } from 'lodash';
 import { NamedLink } from '../../components';
 import { stringify } from '../../util/urlHelpers';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import NextPageIcon from './NextPageIcon';
 import PrevPageIcon from './PrevPageIcon';

--- a/src/components/ResponsiveImage/ResponsiveImage.js
+++ b/src/components/ResponsiveImage/ResponsiveImage.js
@@ -34,7 +34,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import NoImageIcon from './NoImageIcon';
 import css from './ResponsiveImage.css';

--- a/src/components/ReviewModal/ReviewModal.js
+++ b/src/components/ReviewModal/ReviewModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { IconReviewUser, Modal } from '../../components';
 import { ReviewForm } from '../../containers';
 

--- a/src/components/ReviewRating/ReviewRating.js
+++ b/src/components/ReviewRating/ReviewRating.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { IconReviewStar } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { REVIEW_RATINGS } from '../../util/types';
 
 const ReviewRating = props => {
   const { className, rootClassName, reviewStarClassName, rating } = props;
   const classes = classNames(rootClassName, className);
 
-  const stars = propTypes.REVIEW_RATINGS;
+  const stars = REVIEW_RATINGS;
   return (
     <span className={classes}>
       {stars.map(star => (
@@ -31,7 +31,7 @@ ReviewRating.defaultProps = {
 const { string, oneOf } = PropTypes;
 
 ReviewRating.propTypes = {
-  rating: oneOf(propTypes.REVIEW_RATINGS).isRequired,
+  rating: oneOf(REVIEW_RATINGS).isRequired,
   reviewStartClassName: string,
   rootClassName: string,
   className: string,

--- a/src/components/Reviews/Reviews.js
+++ b/src/components/Reviews/Reviews.js
@@ -3,7 +3,7 @@ import { injectIntl, intlShape } from 'react-intl';
 import { arrayOf, string } from 'prop-types';
 import classNames from 'classnames';
 import { Avatar, ReviewRating } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './Reviews.css';
 

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -4,7 +4,7 @@ import { withGoogleMap, GoogleMap } from 'react-google-maps';
 import classNames from 'classnames';
 import { groupBy, isEqual, reduce } from 'lodash';
 import { types as sdkTypes } from '../../util/sdkLoader';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { googleBoundsToSDKBounds } from '../../util/googleMaps';
 import { SearchMapInfoCard, SearchMapPriceLabel, SearchMapGroupLabel } from '../../components';
 

--- a/src/components/SearchMapGroupLabel/SearchMapGroupLabel.js
+++ b/src/components/SearchMapGroupLabel/SearchMapGroupLabel.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { OverlayView } from 'react-google-maps';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureListing } from '../../util/data';
 
 import css from './SearchMapGroupLabel.css';

--- a/src/components/SearchMapInfoCard/SearchMapInfoCard.js
+++ b/src/components/SearchMapInfoCard/SearchMapInfoCard.js
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import config from '../../config';
 import routeConfiguration from '../../routeConfiguration';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { formatMoney } from '../../util/currency';
 import { ensureListing } from '../../util/data';
 import { createResourceLocatorString } from '../../util/routes';

--- a/src/components/SearchMapPriceLabel/SearchMapPriceLabel.js
+++ b/src/components/SearchMapPriceLabel/SearchMapPriceLabel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { OverlayView } from 'react-google-maps';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { formatMoney } from '../../util/currency';
 import { ensureListing } from '../../util/data';
 import config from '../../config';

--- a/src/components/SearchResultsPanel/SearchResultsPanel.js
+++ b/src/components/SearchResultsPanel/SearchResultsPanel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ListingCard, PaginationLinks } from '../../components';
 import css from './SearchResultsPanel.css';
 

--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -10,7 +10,7 @@ import { ensureCurrentUser } from '../../util/data';
 import { withViewport } from '../../util/contextHelpers';
 import { parse, stringify } from '../../util/urlHelpers';
 import { createResourceLocatorString, pathByRouteName } from '../../util/routes';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { isTooManyEmailVerificationRequestsError } from '../../util/errors';
 import {
   Button,

--- a/src/components/TopbarDesktop/TopbarDesktop.js
+++ b/src/components/TopbarDesktop/TopbarDesktop.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import { ACCOUNT_SETTINGS_PAGES } from '../../routeConfiguration';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import {
   Avatar,
   InlineTextButton,

--- a/src/components/TopbarMobileMenu/TopbarMobileMenu.js
+++ b/src/components/TopbarMobileMenu/TopbarMobileMenu.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import { ACCOUNT_SETTINGS_PAGES } from '../../routeConfiguration';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureCurrentUser } from '../../util/data';
 import { AvatarLarge, InlineTextButton, NamedLink, NotificationBadge } from '../../components';
 

--- a/src/components/TransactionPanel/TransactionPanel.helpers.js
+++ b/src/components/TransactionPanel/TransactionPanel.helpers.js
@@ -1,7 +1,17 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import {
+  txHasFirstReview,
+  txIsAccepted,
+  txIsAutodeclined,
+  txIsCanceled,
+  txIsDeclined,
+  txIsDelivered,
+  txIsEnquired,
+  txIsPreauthorized,
+  txIsReviewed,
+} from '../../util/types';
 import { userDisplayName } from '../../util/data';
 import { createSlug } from '../../util/urlHelpers';
 import {
@@ -194,7 +204,7 @@ export const OrderTitle = props => {
 
   const classes = classNames(rootClassName || css.headingOrder, className);
 
-  if (propTypes.txIsEnquired(transaction)) {
+  if (txIsEnquired(transaction)) {
     return (
       <h1 className={classes}>
         <span className={css.mainTitle}>
@@ -202,7 +212,7 @@ export const OrderTitle = props => {
         </span>
       </h1>
     );
-  } else if (propTypes.txIsPreauthorized(transaction)) {
+  } else if (txIsPreauthorized(transaction)) {
     return (
       <h1 className={classes}>
         <span className={css.mainTitle}>
@@ -217,7 +227,7 @@ export const OrderTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsAccepted(transaction)) {
+  } else if (txIsAccepted(transaction)) {
     return (
       <h1 className={classes}>
         <span className={css.mainTitle}>
@@ -226,7 +236,7 @@ export const OrderTitle = props => {
         <FormattedMessage id="TransactionPanel.orderAcceptedSubtitle" values={{ listingLink }} />
       </h1>
     );
-  } else if (propTypes.txIsDeclined(transaction)) {
+  } else if (txIsDeclined(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -235,7 +245,7 @@ export const OrderTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsAutodeclined(transaction)) {
+  } else if (txIsAutodeclined(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -244,7 +254,7 @@ export const OrderTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsCanceled(transaction)) {
+  } else if (txIsCanceled(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -254,9 +264,9 @@ export const OrderTitle = props => {
       </h1>
     );
   } else if (
-    propTypes.txIsDelivered(transaction) ||
-    propTypes.txHasFirstReview(transaction) ||
-    propTypes.txIsReviewed(transaction)
+    txIsDelivered(transaction) ||
+    txHasFirstReview(transaction) ||
+    txIsReviewed(transaction)
   ) {
     return (
       <h1 className={classes}>
@@ -282,7 +292,7 @@ export const OrderMessage = props => {
   } = props;
   const classes = classNames(rootClassName || css.transactionInfoMessage, className);
 
-  if (!listingDeleted && propTypes.txIsPreauthorized(transaction)) {
+  if (!listingDeleted && txIsPreauthorized(transaction)) {
     return (
       <p className={classes}>
         <FormattedMessage id="TransactionPanel.orderPreauthorizedInfo" values={{ providerName }} />
@@ -312,7 +322,7 @@ export const SaleTitle = props => {
 
   const classes = classNames(rootClassName || css.headingSale, className);
 
-  if (propTypes.txIsEnquired(transaction)) {
+  if (txIsEnquired(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -321,7 +331,7 @@ export const SaleTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsPreauthorized(transaction)) {
+  } else if (txIsPreauthorized(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -330,7 +340,7 @@ export const SaleTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsAccepted(transaction)) {
+  } else if (txIsAccepted(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -339,7 +349,7 @@ export const SaleTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsDeclined(transaction)) {
+  } else if (txIsDeclined(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -348,7 +358,7 @@ export const SaleTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsAutodeclined(transaction)) {
+  } else if (txIsAutodeclined(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -357,7 +367,7 @@ export const SaleTitle = props => {
         />
       </h1>
     );
-  } else if (propTypes.txIsCanceled(transaction)) {
+  } else if (txIsCanceled(transaction)) {
     return (
       <h1 className={classes}>
         <FormattedMessage
@@ -367,9 +377,9 @@ export const SaleTitle = props => {
       </h1>
     );
   } else if (
-    propTypes.txIsDelivered(transaction) ||
-    propTypes.txHasFirstReview(transaction) ||
-    propTypes.txIsReviewed(transaction)
+    txIsDelivered(transaction) ||
+    txHasFirstReview(transaction) ||
+    txIsReviewed(transaction)
   ) {
     return (
       <h1 className={classes}>
@@ -395,7 +405,7 @@ export const SaleMessage = props => {
   } = props;
   const classes = classNames(rootClassName || css.transactionInfoMessage, className);
 
-  if (!isCustomerBanned && propTypes.txIsPreauthorized(transaction)) {
+  if (!isCustomerBanned && txIsPreauthorized(transaction)) {
     return (
       <p className={classes}>
         <FormattedMessage id="TransactionPanel.saleRequestedInfo" values={{ customerName }} />

--- a/src/components/TransactionPanel/TransactionPanel.js
+++ b/src/components/TransactionPanel/TransactionPanel.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { txIsEnquired, txIsPreauthorized, propTypes } from '../../util/types';
 import { ensureListing, ensureTransaction, ensureUser } from '../../util/data';
 import { isMobileSafari } from '../../util/userAgent';
 import { AvatarMedium, AvatarLarge, ResponsiveImage, ReviewModal } from '../../components';
@@ -140,11 +140,10 @@ export class TransactionPanelComponent extends Component {
     const customerLoaded = !!currentCustomer.id;
     const isCustomerBanned = customerLoaded && currentCustomer.attributes.banned;
     const canShowSaleButtons =
-      isProvider && propTypes.txIsPreauthorized(currentTransaction) && !isCustomerBanned;
+      isProvider && txIsPreauthorized(currentTransaction) && !isCustomerBanned;
     const isProviderLoaded = !!currentProvider.id;
     const isProviderBanned = isProviderLoaded && currentProvider.attributes.banned;
-    const canShowBookButton =
-      isCustomer && propTypes.txIsEnquired(currentTransaction) && !isProviderBanned;
+    const canShowBookButton = isCustomer && txIsEnquired(currentTransaction) && !isProviderBanned;
 
     const bannedUserDisplayName = intl.formatMessage({
       id: 'TransactionPanel.bannedUserDisplayName',
@@ -209,8 +208,7 @@ export class TransactionPanelComponent extends Component {
         this.isMobSaf && this.state.sendMessageFormFocused,
     });
 
-    const showInfoMessage =
-      listingDeleted || (!listingDeleted && propTypes.txIsPreauthorized(transaction)); // !!orderInfoMessage;
+    const showInfoMessage = listingDeleted || (!listingDeleted && txIsPreauthorized(transaction)); // !!orderInfoMessage;
 
     const feedContainerClasses = classNames(css.feedContainer, {
       [css.feedContainerWithInfoAbove]: showInfoMessage,

--- a/src/components/TransactionPanel/TransactionPanel.test.js
+++ b/src/components/TransactionPanel/TransactionPanel.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import {
   createTransaction,
   createBooking,
@@ -11,13 +11,21 @@ import {
 } from '../../util/test-data';
 import { renderShallow } from '../../util/test-helpers';
 import { fakeIntl } from '../../util/test-data';
-import * as propTypes from '../../util/propTypes';
+import {
+  TX_TRANSITION_ACCEPT,
+  TX_TRANSITION_AUTO_DECLINE,
+  TX_TRANSITION_CANCELED,
+  TX_TRANSITION_DECLINE,
+  TX_TRANSITION_ENQUIRE,
+  TX_TRANSITION_MARK_DELIVERED,
+  TX_TRANSITION_PREAUTHORIZE,
+} from '../../util/types';
 import { BreakdownMaybe } from './TransactionPanel.helpers';
 import { TransactionPanelComponent } from './TransactionPanel';
 
 const noop = () => null;
 
-const { Money } = types;
+const { Money } = sdkTypes;
 
 describe('TransactionPanel - Sale', () => {
   const baseTxAttrs = {
@@ -34,43 +42,43 @@ describe('TransactionPanel - Sale', () => {
 
   const txEnquired = createTransaction({
     id: 'sale-enquired',
-    lastTransition: propTypes.TX_TRANSITION_ENQUIRE,
+    lastTransition: TX_TRANSITION_ENQUIRE,
     ...baseTxAttrs,
   });
 
   const txPreauthorized = createTransaction({
     id: 'sale-preauthorized',
-    lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+    lastTransition: TX_TRANSITION_PREAUTHORIZE,
     ...baseTxAttrs,
   });
 
   const txAccepted = createTransaction({
     id: 'sale-accepted',
-    lastTransition: propTypes.TX_TRANSITION_ACCEPT,
+    lastTransition: TX_TRANSITION_ACCEPT,
     ...baseTxAttrs,
   });
 
   const txDeclined = createTransaction({
     id: 'sale-declined',
-    lastTransition: propTypes.TX_TRANSITION_DECLINE,
+    lastTransition: TX_TRANSITION_DECLINE,
     ...baseTxAttrs,
   });
 
   const txAutoDeclined = createTransaction({
     id: 'sale-autodeclined',
-    lastTransition: propTypes.TX_TRANSITION_AUTO_DECLINE,
+    lastTransition: TX_TRANSITION_AUTO_DECLINE,
     ...baseTxAttrs,
   });
 
   const txCanceled = createTransaction({
     id: 'sale-canceled',
-    lastTransition: propTypes.TX_TRANSITION_CANCELED,
+    lastTransition: TX_TRANSITION_CANCELED,
     ...baseTxAttrs,
   });
 
   const txDelivered = createTransaction({
     id: 'sale-delivered',
-    lastTransition: propTypes.TX_TRANSITION_MARK_DELIVERED,
+    lastTransition: TX_TRANSITION_MARK_DELIVERED,
     ...baseTxAttrs,
   });
 
@@ -159,7 +167,7 @@ describe('TransactionPanel - Sale', () => {
   it('renders correct total price', () => {
     const transaction = createTransaction({
       id: 'sale-tx',
-      lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      lastTransition: TX_TRANSITION_PREAUTHORIZE,
       total: new Money(16500, 'USD'),
       commission: new Money(1000, 'USD'),
       booking: createBooking('booking1', {
@@ -199,43 +207,43 @@ describe('TransactionPanel - Order', () => {
 
   const txEnquired = createTransaction({
     id: 'order-enquired',
-    lastTransition: propTypes.TX_TRANSITION_ENQUIRE,
+    lastTransition: TX_TRANSITION_ENQUIRE,
     ...baseTxAttrs,
   });
 
   const txPreauthorized = createTransaction({
     id: 'order-preauthorized',
-    lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+    lastTransition: TX_TRANSITION_PREAUTHORIZE,
     ...baseTxAttrs,
   });
 
   const txAccepted = createTransaction({
     id: 'order-accepted',
-    lastTransition: propTypes.TX_TRANSITION_ACCEPT,
+    lastTransition: TX_TRANSITION_ACCEPT,
     ...baseTxAttrs,
   });
 
   const txDeclined = createTransaction({
     id: 'order-declined',
-    lastTransition: propTypes.TX_TRANSITION_DECLINE,
+    lastTransition: TX_TRANSITION_DECLINE,
     ...baseTxAttrs,
   });
 
   const txAutoDeclined = createTransaction({
     id: 'order-autodeclined',
-    lastTransition: propTypes.TX_TRANSITION_AUTO_DECLINE,
+    lastTransition: TX_TRANSITION_AUTO_DECLINE,
     ...baseTxAttrs,
   });
 
   const txCanceled = createTransaction({
     id: 'order-canceled',
-    lastTransition: propTypes.TX_TRANSITION_CANCELED,
+    lastTransition: TX_TRANSITION_CANCELED,
     ...baseTxAttrs,
   });
 
   const txDelivered = createTransaction({
     id: 'order-delivered',
-    lastTransition: propTypes.TX_TRANSITION_MARK_DELIVERED,
+    lastTransition: TX_TRANSITION_MARK_DELIVERED,
     ...baseTxAttrs,
   });
 
@@ -324,10 +332,9 @@ describe('TransactionPanel - Order', () => {
     expect(tree).toMatchSnapshot();
   });
   it('renders correct total price', () => {
-    const { Money } = types;
     const tx = createTransaction({
       id: 'order-tx',
-      lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      lastTransition: TX_TRANSITION_PREAUTHORIZE,
       total: new Money(16500, 'USD'),
       booking: createBooking('booking1', {
         start: new Date(Date.UTC(2017, 5, 10)),

--- a/src/components/UserCard/UserCard.example.js
+++ b/src/components/UserCard/UserCard.example.js
@@ -1,8 +1,8 @@
 import { createUser, createCurrentUser } from '../../util/test-data';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import UserCard from './UserCard';
 
-const { UUID } = types;
+const { UUID } = sdkTypes;
 
 export const EmptyUser = {
   component: UserCard,

--- a/src/components/UserCard/UserCard.js
+++ b/src/components/UserCard/UserCard.js
@@ -5,7 +5,7 @@ import { truncate } from 'lodash';
 import classNames from 'classnames';
 import { AvatarLarge, NamedLink, InlineTextButton } from '../../components';
 import { ensureUser, ensureCurrentUser } from '../../util/data';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './UserCard.css';
 

--- a/src/containers/AuthenticationPage/AuthenticationPage.js
+++ b/src/containers/AuthenticationPage/AuthenticationPage.js
@@ -6,7 +6,7 @@ import { withRouter, Redirect } from 'react-router-dom';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import config from '../../config';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureCurrentUser } from '../../util/data';
 import {
   isSignupEmailTakenError,

--- a/src/containers/BookingDatesForm/BookingDatesForm.example.js
+++ b/src/containers/BookingDatesForm/BookingDatesForm.example.js
@@ -1,16 +1,18 @@
 /* eslint-disable no-console */
-import { types } from '../../util/sdkLoader';
-import * as propTypes from '../../util/propTypes';
+import { types as sdkTypes } from '../../util/sdkLoader';
+import { LINE_ITEM_NIGHT } from '../../util/types';
 import BookingDatesForm from './BookingDatesForm';
+
+const { Money } = sdkTypes;
 
 export const Form = {
   component: BookingDatesForm,
   props: {
-    unitType: propTypes.LINE_ITEM_NIGHT,
+    unitType: LINE_ITEM_NIGHT,
     onSubmit: values => {
       console.log('Submit BookingDatesForm with values:', values);
     },
-    price: new types.Money(1099, 'USD'),
+    price: new Money(1099, 'USD'),
   },
   group: 'forms',
 };

--- a/src/containers/BookingDatesForm/BookingDatesForm.js
+++ b/src/containers/BookingDatesForm/BookingDatesForm.js
@@ -7,20 +7,28 @@ import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 import moment from 'moment';
 import Decimal from 'decimal.js';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { required, bookingDatesRequired } from '../../util/validators';
 import { nightsBetween, daysBetween, START_DATE, END_DATE } from '../../util/dates';
 import { unitDivisor, convertMoneyToNumber, convertUnitToSubUnit } from '../../util/currency';
-import * as propTypes from '../../util/propTypes';
+import {
+  LINE_ITEM_DAY,
+  LINE_ITEM_NIGHT,
+  TX_TRANSITION_ACTOR_CUSTOMER,
+  TX_TRANSITION_PREAUTHORIZE,
+  propTypes,
+} from '../../util/types';
 import config from '../../config';
 import { Form, PrimaryButton, BookingBreakdown, DateRangeInputField } from '../../components';
 
 import css from './BookingDatesForm.css';
 
+const { Money, UUID } = sdkTypes;
+
 const estimatedTotalPrice = (unitPrice, unitCount) => {
   const numericPrice = convertMoneyToNumber(unitPrice);
   const numericTotalPrice = new Decimal(numericPrice).times(unitCount).toNumber();
-  return new types.Money(
+  return new Money(
     convertUnitToSubUnit(numericTotalPrice, unitDivisor(unitPrice.currency)),
     unitPrice.currency
   );
@@ -31,24 +39,24 @@ const estimatedTotalPrice = (unitPrice, unitCount) => {
 // an estimated transaction object for that use case.
 const estimatedTransaction = (unitType, bookingStart, bookingEnd, unitPrice) => {
   const now = new Date();
-  const isNightly = unitType === propTypes.LINE_ITEM_NIGHT;
+  const isNightly = unitType === LINE_ITEM_NIGHT;
   const unitCount = isNightly
     ? nightsBetween(bookingStart, bookingEnd)
     : daysBetween(bookingStart, bookingEnd);
   const totalPrice = estimatedTotalPrice(unitPrice, unitCount);
 
   return {
-    id: new types.UUID('estimated-transaction'),
+    id: new UUID('estimated-transaction'),
     type: 'transaction',
     attributes: {
       createdAt: now,
       lastTransitionedAt: now,
-      lastTransition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+      lastTransition: TX_TRANSITION_PREAUTHORIZE,
       payinTotal: totalPrice,
       payoutTotal: totalPrice,
       lineItems: [
         {
-          code: isNightly ? propTypes.LINE_ITEM_NIGHT : propTypes.LINE_ITEM_DAY,
+          code: isNightly ? LINE_ITEM_NIGHT : LINE_ITEM_DAY,
           includeFor: ['customer', 'provider'],
           unitPrice: unitPrice,
           quantity: new Decimal(unitCount),
@@ -59,13 +67,13 @@ const estimatedTransaction = (unitType, bookingStart, bookingEnd, unitPrice) => 
       transitions: [
         {
           at: now,
-          by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-          transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+          by: TX_TRANSITION_ACTOR_CUSTOMER,
+          transition: TX_TRANSITION_PREAUTHORIZE,
         },
       ],
     },
     booking: {
-      id: new types.UUID('estimated-booking'),
+      id: new UUID('estimated-booking'),
       type: 'booking',
       attributes: {
         start: bookingStart,
@@ -251,7 +259,7 @@ BookingDatesFormComponent.propTypes = {
   className: string,
 
   unitType: propTypes.bookingUnitType.isRequired,
-  price: instanceOf(types.Money),
+  price: propTypes.money,
   isOwnListing: bool,
 
   // from formValueSelector

--- a/src/containers/BookingDatesForm/BookingDatesForm.test.js
+++ b/src/containers/BookingDatesForm/BookingDatesForm.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Decimal from 'decimal.js';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { renderShallow } from '../../util/test-helpers';
 import { fakeIntl, fakeFormProps } from '../../util/test-data';
-import * as propTypes from '../../util/propTypes';
+import { LINE_ITEM_NIGHT, TX_TRANSITION_PREAUTHORIZE } from '../../util/types';
 import { BookingBreakdown } from '../../components';
 import { BookingDatesFormComponent } from './BookingDatesForm';
 
-const { Money } = types;
+const { Money } = sdkTypes;
 
 const noop = () => null;
 
@@ -17,7 +17,7 @@ describe('BookingDatesForm', () => {
     const tree = renderShallow(
       <BookingDatesFormComponent
         {...fakeFormProps}
-        unitType={propTypes.LINE_ITEM_NIGHT}
+        unitType={LINE_ITEM_NIGHT}
         intl={fakeIntl}
         dispatch={noop}
         onSubmit={v => v}
@@ -36,7 +36,7 @@ describe('BookingDatesForm', () => {
     const tree = shallow(
       <BookingDatesFormComponent
         {...fakeFormProps}
-        unitType={propTypes.LINE_ITEM_NIGHT}
+        unitType={LINE_ITEM_NIGHT}
         intl={fakeIntl}
         dispatch={noop}
         onSubmit={v => v}
@@ -51,7 +51,7 @@ describe('BookingDatesForm', () => {
     expect(userRole).toEqual('customer');
     expect(booking.attributes.start).toEqual(startDate);
     expect(booking.attributes.end).toEqual(endDate);
-    expect(transaction.attributes.lastTransition).toEqual(propTypes.TX_TRANSITION_PREAUTHORIZE);
+    expect(transaction.attributes.lastTransition).toEqual(TX_TRANSITION_PREAUTHORIZE);
     expect(transaction.attributes.payinTotal).toEqual(new Money(2198, 'USD'));
     expect(transaction.attributes.payoutTotal).toEqual(new Money(2198, 'USD'));
     expect(transaction.attributes.lineItems).toEqual([

--- a/src/containers/CheckoutPage/CheckoutPage.duck.js
+++ b/src/containers/CheckoutPage/CheckoutPage.duck.js
@@ -1,7 +1,7 @@
 import { pick } from 'lodash';
 import { updatedEntities, denormalisedEntities } from '../../util/data';
 import { storableError } from '../../util/errors';
-import * as propTypes from '../../util/propTypes';
+import { TX_TRANSITION_PREAUTHORIZE } from '../../util/types';
 import * as log from '../../util/log';
 import { fetchCurrentUserHasOrdersSuccess } from '../../ducks/user.duck';
 
@@ -107,7 +107,7 @@ export const speculateTransactionError = e => ({
 export const initiateOrder = (orderParams, initialMessage) => (dispatch, getState, sdk) => {
   dispatch(initiateOrderRequest());
   const bodyParams = {
-    transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+    transition: TX_TRANSITION_PREAUTHORIZE,
     params: orderParams,
   };
   return sdk.transactions
@@ -161,7 +161,7 @@ export const speculateTransaction = (listingId, bookingStart, bookingEnd) => (
 ) => {
   dispatch(speculateTransactionRequest());
   const bodyParams = {
-    transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+    transition: TX_TRANSITION_PREAUTHORIZE,
     params: {
       listingId,
       bookingStart,

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 import classNames from 'classnames';
 import routeConfiguration from '../../routeConfiguration';
 import { pathByRouteName, findRouteByRouteName } from '../../util/routes';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureListing, ensureUser, ensureTransaction, ensureBooking } from '../../util/data';
 import { createSlug } from '../../util/urlHelpers';
 import {

--- a/src/containers/CheckoutPage/CheckoutPageSessionHelpers.js
+++ b/src/containers/CheckoutPage/CheckoutPageSessionHelpers.js
@@ -6,7 +6,9 @@
  */
 import moment from 'moment';
 import { reduce } from 'lodash';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
+
+const { UUID, Money } = sdkTypes;
 
 // Validate that given 'obj' has all the keys of defined by validPropTypes parameter
 // and values must pass related test-value-format function.
@@ -36,9 +38,9 @@ export const isValidBookingDates = bookingDates => {
 // Currently only id & attributes.price are needed.
 export const isValidListing = listing => {
   const props = {
-    id: id => id instanceof types.UUID,
+    id: id => id instanceof UUID,
     attributes: v => {
-      return typeof v === 'object' && v.price instanceof types.Money;
+      return typeof v === 'object' && v.price instanceof Money;
     },
   };
   return validateProperties(listing, props);
@@ -60,7 +62,7 @@ export const storeData = (bookingDates, listing, storageKey) => {
     };
     /* eslint-enable no-underscore-dangle */
 
-    const storableData = JSON.stringify(data, types.replacer);
+    const storableData = JSON.stringify(data, sdkTypes.replacer);
     window.sessionStorage.setItem(storageKey, storableData);
   }
 };
@@ -77,7 +79,7 @@ export const storedData = storageKey => {
       if (v && typeof v === 'object' && v._serializedType === 'SerializableDate') {
         return new Date(v.date);
       }
-      return types.reviver(k, v);
+      return sdkTypes.reviver(k, v);
     };
 
     const { bookingDates, listing, storedAt } = checkoutPageData

--- a/src/containers/ContactDetailsForm/ContactDetailsForm.js
+++ b/src/containers/ContactDetailsForm/ContactDetailsForm.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import * as validators from '../../util/validators';
 import { ensureCurrentUser } from '../../util/data';
 import {

--- a/src/containers/ContactDetailsPage/ContactDetailsPage.js
+++ b/src/containers/ContactDetailsPage/ContactDetailsPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureCurrentUser } from '../../util/data';
 import { fetchCurrentUser, sendVerificationEmail } from '../../ducks/user.duck';
 import {

--- a/src/containers/EditListingDescriptionForm/EditListingDescriptionForm.js
+++ b/src/containers/EditListingDescriptionForm/EditListingDescriptionForm.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { maxLength, required } from '../../util/validators';
 import { FieldCustomAttributeSelect, Form, Button, TextInputField } from '../../components';
 

--- a/src/containers/EditListingLocationForm/EditListingLocationForm.js
+++ b/src/containers/EditListingLocationForm/EditListingLocationForm.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { reduxForm, formValueSelector, propTypes as formPropTypes } from 'redux-form';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { autocompleteSearchRequired, autocompletePlaceSelected } from '../../util/validators';
 import { Form, LocationAutocompleteInputField, Button, TextInputField } from '../../components';
 

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -1,9 +1,11 @@
 import { omit, omitBy, isUndefined } from 'lodash';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { storableError } from '../../util/errors';
 import { addMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import * as log from '../../util/log';
 import { fetchCurrentUserHasListingsSuccess } from '../../ducks/user.duck';
+
+const { UUID } = sdkTypes;
 
 const requestAction = actionType => params => ({ type: actionType, payload: { params } });
 
@@ -339,7 +341,7 @@ export function loadData(params) {
       return Promise.resolve(null);
     }
     const payload = {
-      id: new types.UUID(id),
+      id: new UUID(id),
       include: ['author', 'images'],
     };
     return dispatch(requestShowListing(payload));

--- a/src/containers/EditListingPage/EditListingPage.js
+++ b/src/containers/EditListingPage/EditListingPage.js
@@ -4,9 +4,9 @@ import { compose } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { intlShape, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { createSlug } from '../../util/urlHelpers';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { getListingsById } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/UI.duck';
 import { stripeAccountClearError, createStripeAccount } from '../../ducks/user.duck';
@@ -26,6 +26,8 @@ import {
 } from './EditListingPage.duck';
 
 import css from './EditListingPage.css';
+
+const { UUID } = sdkTypes;
 
 const formatRequestData = values => {
   const { address, description, images, geolocation, price, title, customAttributes } = values;
@@ -70,7 +72,7 @@ export const EditListingPageComponent = props => {
 
   const isNew = type === 'new';
   const newListingCreated = isNew && !!page.submittedListingId;
-  const listingId = page.submittedListingId || (id ? new types.UUID(id) : null);
+  const listingId = page.submittedListingId || (id ? new UUID(id) : null);
   const currentListing = getListing(listingId);
 
   const shouldRedirect = page.submittedListingId && currentListing;

--- a/src/containers/EditListingPhotosForm/EditListingPhotosForm.js
+++ b/src/containers/EditListingPhotosForm/EditListingPhotosForm.js
@@ -6,7 +6,7 @@ import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { isEqual } from 'lodash';
 import { arrayMove } from 'react-sortable-hoc';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { noEmptyArray } from '../../util/validators';
 import { isUploadListingImageOverLimitError } from '../../util/errors';
 import { Form, AddImages, Button, ValidationError } from '../../components';

--- a/src/containers/EditListingPricingForm/EditListingPricingForm.js
+++ b/src/containers/EditListingPricingForm/EditListingPricingForm.js
@@ -5,7 +5,7 @@ import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import config from '../../config';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { required } from '../../util/validators';
 import { Form, Button, CurrencyInputField } from '../../components';
 

--- a/src/containers/EmailVerificationForm/EmailVerificationForm.js
+++ b/src/containers/EmailVerificationForm/EmailVerificationForm.js
@@ -10,7 +10,7 @@ import {
   IconEmailSuccess,
   PrimaryButton,
 } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './EmailVerificationForm.css';
 

--- a/src/containers/EmailVerificationPage/EmailVerificationPage.js
+++ b/src/containers/EmailVerificationPage/EmailVerificationPage.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { verify } from '../../ducks/EmailVerification.duck';
 import { isScrollingDisabled } from '../../ducks/UI.duck';
 import { parse } from '../../util/urlHelpers';

--- a/src/containers/EnquiryForm/EnquiryForm.js
+++ b/src/containers/EnquiryForm/EnquiryForm.js
@@ -6,7 +6,7 @@ import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import classNames from 'classnames';
 import { Form, PrimaryButton, TextInputField, IconEnquiry } from '../../components';
 import * as validators from '../../util/validators';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './EnquiryForm.css';
 

--- a/src/containers/InboxPage/InboxPage.js
+++ b/src/containers/InboxPage/InboxPage.js
@@ -5,7 +5,18 @@ import { connect } from 'react-redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import moment from 'moment';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import {
+  LINE_ITEM_DAY,
+  txHasFirstReview,
+  txIsAccepted,
+  txIsCanceled,
+  txIsDeclinedOrAutodeclined,
+  txIsDelivered,
+  txIsEnquired,
+  txIsPreauthorized,
+  txIsReviewed,
+  propTypes,
+} from '../../util/types';
 import { formatMoney } from '../../util/currency';
 import { userDisplayName } from '../../util/data';
 import { daysBetween } from '../../util/dates';
@@ -46,7 +57,7 @@ const formatDate = (intl, date) => {
 
 // Translated name of the state of the given transaction
 const txState = (intl, tx, isOrder) => {
-  if (propTypes.txIsAccepted(tx)) {
+  if (txIsAccepted(tx)) {
     return {
       nameClassName: css.nameAccepted,
       bookingClassName: css.bookingAccepted,
@@ -56,7 +67,7 @@ const txState = (intl, tx, isOrder) => {
         id: 'InboxPage.stateAccepted',
       }),
     };
-  } else if (propTypes.txIsDeclinedOrAutodeclined(tx)) {
+  } else if (txIsDeclinedOrAutodeclined(tx)) {
     return {
       nameClassName: css.nameDeclined,
       bookingClassName: css.bookingDeclined,
@@ -66,7 +77,7 @@ const txState = (intl, tx, isOrder) => {
         id: 'InboxPage.stateDeclined',
       }),
     };
-  } else if (propTypes.txIsCanceled(tx)) {
+  } else if (txIsCanceled(tx)) {
     return {
       nameClassName: css.nameCanceled,
       bookingClassName: css.bookingCanceled,
@@ -76,11 +87,7 @@ const txState = (intl, tx, isOrder) => {
         id: 'InboxPage.stateCanceled',
       }),
     };
-  } else if (
-    propTypes.txIsDelivered(tx) ||
-    propTypes.txHasFirstReview(tx) ||
-    propTypes.txIsReviewed(tx)
-  ) {
+  } else if (txIsDelivered(tx) || txHasFirstReview(tx) || txIsReviewed(tx)) {
     return {
       nameClassName: css.nameDelivered,
       bookingClassName: css.bookingDelivered,
@@ -90,7 +97,7 @@ const txState = (intl, tx, isOrder) => {
         id: 'InboxPage.stateDelivered',
       }),
     };
-  } else if (propTypes.txIsEnquired(tx)) {
+  } else if (txIsEnquired(tx)) {
     return {
       nameClassName: isOrder ? css.nameEnquiredOrder : css.nameEnquired,
       bookingClassName: css.bookingEnquired,
@@ -120,7 +127,7 @@ const txState = (intl, tx, isOrder) => {
 
 const bookingData = (unitType, tx, isOrder, intl) => {
   const { start, end } = tx.booking.attributes;
-  const isDaily = unitType === propTypes.LINE_ITEM_DAY;
+  const isDaily = unitType === LINE_ITEM_DAY;
   const isSingleDay = isDaily && daysBetween(start, end) === 1;
   const bookingStart = formatDate(intl, start);
 
@@ -149,11 +156,11 @@ export const InboxItem = props => {
   const otherUserDisplayName = userDisplayName(otherUser, bannedUserDisplayName);
 
   const stateData = txState(intl, tx, isOrder);
-  const isSaleNotification = !isOrder && propTypes.txIsPreauthorized(tx);
+  const isSaleNotification = !isOrder && txIsPreauthorized(tx);
   const rowNotificationDot = isSaleNotification ? <div className={css.notificationDot} /> : null;
   const lastTransitionedAt = formatDate(intl, tx.attributes.lastTransitionedAt);
 
-  const isEnquiry = propTypes.txIsEnquired(tx);
+  const isEnquiry = txIsEnquired(tx);
   const { bookingStart, bookingEnd, price, isSingleDay } = isEnquiry
     ? {}
     : bookingData(unitType, tx, isOrder, intl);

--- a/src/containers/InboxPage/InboxPage.test.js
+++ b/src/containers/InboxPage/InboxPage.test.js
@@ -10,7 +10,7 @@ import {
 } from '../../util/test-data';
 import { InboxPageComponent, InboxItem } from './InboxPage';
 import routeConfiguration from '../../routeConfiguration';
-import { TX_TRANSITION_PREAUTHORIZE, LINE_ITEM_NIGHT } from '../../util/propTypes';
+import { LINE_ITEM_NIGHT, TX_TRANSITION_PREAUTHORIZE } from '../../util/types';
 
 const noop = () => null;
 

--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -1,10 +1,12 @@
 import { pick } from 'lodash';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { storableError } from '../../util/errors';
 import { addMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import { updatedEntities, denormalisedEntities } from '../../util/data';
-import * as propTypes from '../../util/propTypes';
+import { TX_TRANSITION_ENQUIRE } from '../../util/types';
 import { fetchCurrentUser } from '../../ducks/user.duck';
+
+const { UUID } = sdkTypes;
 
 // ================ Action types ================ //
 
@@ -128,7 +130,7 @@ export const fetchReviews = listingId => (dispatch, getState, sdk) => {
 export const sendEnquiry = (listingId, message) => (dispatch, getState, sdk) => {
   dispatch(sendEnquiryRequest());
   const bodyParams = {
-    transition: propTypes.TX_TRANSITION_ENQUIRE,
+    transition: TX_TRANSITION_ENQUIRE,
     params: { listingId },
   };
   return sdk.transactions
@@ -149,7 +151,7 @@ export const sendEnquiry = (listingId, message) => (dispatch, getState, sdk) => 
 };
 
 export const loadData = params => dispatch => {
-  const listingId = new types.UUID(params.id);
+  const listingId = new UUID(params.id);
 
   return Promise.all([dispatch(showListing(listingId)), dispatch(fetchReviews(listingId))]);
 };

--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -7,8 +7,8 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import config from '../../config';
 import routeConfiguration from '../../routeConfiguration';
-import * as propTypes from '../../util/propTypes';
-import { types } from '../../util/sdkLoader';
+import { propTypes } from '../../util/types';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { createSlug } from '../../util/urlHelpers';
 import { formatMoney } from '../../util/currency';
 import { createResourceLocatorString, findRouteByRouteName } from '../../util/routes';
@@ -45,7 +45,7 @@ import css from './ListingPage.css';
 // This defines when ModalInMobile shows content as Modal
 const MODAL_BREAKPOINT = 1023;
 
-const { UUID } = types;
+const { UUID } = sdkTypes;
 
 const priceData = (price, intl) => {
   if (price && price.currency === config.currency) {

--- a/src/containers/ListingPage/ListingPage.test.js
+++ b/src/containers/ListingPage/ListingPage.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { FormattedMessage } from 'react-intl';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { createUser, createCurrentUser, createListing, fakeIntl } from '../../util/test-data';
 import { storableError } from '../../util/errors';
 import { renderShallow } from '../../util/test-helpers';
-import * as propTypes from '../../util/propTypes';
+import { LINE_ITEM_NIGHT } from '../../util/types';
 import { addMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import { showListingRequest, showListingError, showListing } from './ListingPage.duck';
 
@@ -15,7 +15,7 @@ import { showListingRequest, showListingError, showListing } from './ListingPage
 import routeConfiguration from '../../routeConfiguration';
 import { ListingPageComponent, ActionBar } from './ListingPage';
 
-const { UUID } = types;
+const { UUID } = sdkTypes;
 const noop = () => null;
 
 describe('ListingPage', () => {
@@ -27,7 +27,7 @@ describe('ListingPage', () => {
     const getListing = () => listing1;
 
     const props = {
-      unitType: propTypes.LINE_ITEM_NIGHT,
+      unitType: LINE_ITEM_NIGHT,
       location: {
         pathname: `/l/${slug}/${id}`,
         search: '',

--- a/src/containers/ManageListingsPage/ManageListingsPage.js
+++ b/src/containers/ManageListingsPage/ManageListingsPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { parse } from '../../util/urlHelpers';
 import { isScrollingDisabled } from '../../ducks/UI.duck';
 import {

--- a/src/containers/PasswordChangeForm/PasswordChangeForm.js
+++ b/src/containers/PasswordChangeForm/PasswordChangeForm.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import * as validators from '../../util/validators';
 import { ensureCurrentUser } from '../../util/data';
 import { isChangePasswordWrongPassword } from '../../util/errors';

--- a/src/containers/PasswordChangePage/PasswordChangePage.js
+++ b/src/containers/PasswordChangePage/PasswordChangePage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { isScrollingDisabled } from '../../ducks/UI.duck';
 import {
   LayoutSideNavigation,

--- a/src/containers/PasswordRecoveryForm/PasswordRecoveryForm.js
+++ b/src/containers/PasswordRecoveryForm/PasswordRecoveryForm.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import classNames from 'classnames';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import * as validators from '../../util/validators';
 import { isPasswordRecoveryEmailNotFoundError } from '../../util/errors';
 import { Form, PrimaryButton, TextInputField, NamedLink } from '../../components';

--- a/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
+++ b/src/containers/PasswordRecoveryPage/PasswordRecoveryPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import {
   isPasswordRecoveryEmailNotFoundError,
   isPasswordRecoveryEmailNotVerifiedError,

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { parse } from '../../util/urlHelpers';
 import { isScrollingDisabled } from '../../ducks/UI.duck';
 import {

--- a/src/containers/ProfilePage/ProfilePage.js
+++ b/src/containers/ProfilePage/ProfilePage.js
@@ -4,8 +4,8 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { types } from '../../util/sdkLoader';
-import * as propTypes from '../../util/propTypes';
+import { types as sdkTypes } from '../../util/sdkLoader';
+import { REVIEW_TYPE_OF_PROVIDER, REVIEW_TYPE_OF_CUSTOMER, propTypes } from '../../util/types';
 import { ensureCurrentUser, ensureUser } from '../../util/data';
 import { withViewport } from '../../util/contextHelpers';
 import { isScrollingDisabled } from '../../ducks/UI.duck';
@@ -30,7 +30,7 @@ import config from '../../config';
 
 import css from './ProfilePage.css';
 
-const { UUID } = types;
+const { UUID } = sdkTypes;
 const MAX_MOBILE_SCREEN_WIDTH = 768;
 
 export class ProfilePageComponent extends Component {
@@ -39,7 +39,7 @@ export class ProfilePageComponent extends Component {
 
     this.state = {
       // keep track of which reviews tab to show in desktop viewport
-      showReviewsType: propTypes.REVIEW_TYPE_OF_PROVIDER,
+      showReviewsType: REVIEW_TYPE_OF_PROVIDER,
     };
 
     this.showOfProviderReviews = this.showOfProviderReviews.bind(this);
@@ -48,13 +48,13 @@ export class ProfilePageComponent extends Component {
 
   showOfProviderReviews() {
     this.setState({
-      showReviewsType: propTypes.REVIEW_TYPE_OF_PROVIDER,
+      showReviewsType: REVIEW_TYPE_OF_PROVIDER,
     });
   }
 
   showOfCustomerReviews() {
     this.setState({
-      showReviewsType: propTypes.REVIEW_TYPE_OF_CUSTOMER,
+      showReviewsType: REVIEW_TYPE_OF_CUSTOMER,
     });
   }
 
@@ -115,13 +115,9 @@ export class ProfilePageComponent extends Component {
       </p>
     );
 
-    const reviewsOfProvider = reviews.filter(
-      r => r.attributes.type === propTypes.REVIEW_TYPE_OF_PROVIDER
-    );
+    const reviewsOfProvider = reviews.filter(r => r.attributes.type === REVIEW_TYPE_OF_PROVIDER);
 
-    const reviewsOfCustomer = reviews.filter(
-      r => r.attributes.type === propTypes.REVIEW_TYPE_OF_CUSTOMER
-    );
+    const reviewsOfCustomer = reviews.filter(r => r.attributes.type === REVIEW_TYPE_OF_CUSTOMER);
 
     const mobileReviews = (
       <div className={css.mobileReviews}>
@@ -154,7 +150,7 @@ export class ProfilePageComponent extends Component {
             />
           </h3>
         ),
-        selected: this.state.showReviewsType === propTypes.REVIEW_TYPE_OF_PROVIDER,
+        selected: this.state.showReviewsType === REVIEW_TYPE_OF_PROVIDER,
         onClick: this.showOfProviderReviews,
       },
       {
@@ -166,7 +162,7 @@ export class ProfilePageComponent extends Component {
             />
           </h3>
         ),
-        selected: this.state.showReviewsType === propTypes.REVIEW_TYPE_OF_CUSTOMER,
+        selected: this.state.showReviewsType === REVIEW_TYPE_OF_CUSTOMER,
         onClick: this.showOfCustomerReviews,
       },
     ];
@@ -177,7 +173,7 @@ export class ProfilePageComponent extends Component {
 
         {queryReviewsError ? reviewsError : null}
 
-        {this.state.showReviewsType === propTypes.REVIEW_TYPE_OF_PROVIDER ? (
+        {this.state.showReviewsType === REVIEW_TYPE_OF_PROVIDER ? (
           <Reviews reviews={reviewsOfProvider} />
         ) : (
           <Reviews reviews={reviewsOfCustomer} />

--- a/src/containers/ProfileSettingsForm/ProfileSettingsForm.js
+++ b/src/containers/ProfileSettingsForm/ProfileSettingsForm.js
@@ -5,7 +5,7 @@ import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { Field, reduxForm, propTypes as formPropTypes } from 'redux-form';
 import classNames from 'classnames';
 import { ensureCurrentUser } from '../../util/data';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import * as validators from '../../util/validators';
 import { isUploadProfileImageOverLimitError } from '../../util/errors';
 import { Form, Avatar, Button, ImageFromFile, IconSpinner, TextInputField } from '../../components';

--- a/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
+++ b/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureCurrentUser } from '../../util/data';
 import { isScrollingDisabled } from '../../ducks/UI.duck';
 import {

--- a/src/containers/ReviewForm/ReviewForm.js
+++ b/src/containers/ReviewForm/ReviewForm.js
@@ -5,7 +5,7 @@ import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import { isTransactionsTransitionAlreadyReviewed } from '../../util/errors';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { required } from '../../util/validators';
 import { FieldReviewRating, Form, PrimaryButton, TextInputField } from '../../components';
 

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -16,7 +16,7 @@ import {
 } from '../../util/googleMaps';
 import { createResourceLocatorString } from '../../util/routes';
 import { createSlug, parse, stringify } from '../../util/urlHelpers';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { getListingsById } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/UI.duck';
 import {

--- a/src/containers/SearchPage/SearchPage.test.js
+++ b/src/containers/SearchPage/SearchPage.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderShallow } from '../../util/test-helpers';
 import { fakeIntl } from '../../util/test-data';
-import { types } from '../../util/sdkLoader';
+import { types as sdkTypes } from '../../util/sdkLoader';
 import { SearchPageComponent } from './SearchPage';
 import reducer, {
   ADD_FILTER,
@@ -13,7 +13,7 @@ import reducer, {
   watchLoadListings,
 } from './SearchPage.duck';
 
-const { LatLng } = types;
+const { LatLng } = sdkTypes;
 const noop = () => null;
 
 describe('SearchPageComponent', () => {

--- a/src/containers/SendMessageForm/SendMessageForm.js
+++ b/src/containers/SendMessageForm/SendMessageForm.js
@@ -5,7 +5,7 @@ import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, propTypes as formPropTypes } from 'redux-form';
 import classNames from 'classnames';
 import { Form, TextInputField, SecondaryButton, IconSpinner } from '../../components';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 
 import css from './SendMessageForm.css';
 

--- a/src/containers/TopbarContainer/TopbarContainer.js
+++ b/src/containers/TopbarContainer/TopbarContainer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { sendVerificationEmail, hasCurrentUserErrors } from '../../ducks/user.duck';
 import { logout, authenticationInProgress } from '../../ducks/Auth.duck';
 import { manageDisableScrolling } from '../../ducks/UI.duck';

--- a/src/containers/TransactionPage/TransactionPage.js
+++ b/src/containers/TransactionPage/TransactionPage.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { reset as resetForm } from 'redux-form';
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
 import { ensureListing, ensureTransaction } from '../../util/data';
 import { getMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import { isScrollingDisabled, manageDisableScrolling } from '../../ducks/UI.duck';

--- a/src/containers/TransactionPage/TransactionPage.test.js
+++ b/src/containers/TransactionPage/TransactionPage.test.js
@@ -8,7 +8,7 @@ import {
   fakeIntl,
 } from '../../util/test-data';
 import { renderShallow } from '../../util/test-helpers';
-import { TX_TRANSITION_PREAUTHORIZE } from '../../util/propTypes';
+import { TX_TRANSITION_PREAUTHORIZE } from '../../util/types';
 import { TransactionPageComponent } from './TransactionPage';
 
 const noop = () => null;

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -1,6 +1,6 @@
 import { updatedEntities, denormalisedEntities } from '../util/data';
 import { storableError } from '../util/errors';
-import { TX_TRANSITION_PREAUTHORIZE, TX_TRANSITION_PREAUTHORIZE_ENQUIRY } from '../util/propTypes';
+import { TX_TRANSITION_PREAUTHORIZE, TX_TRANSITION_PREAUTHORIZE_ENQUIRY } from '../util/types';
 import * as log from '../util/log';
 import { authInfo } from './Auth.duck';
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Decimal from 'decimal.js';
-import { createInstance, types } from './util/sdkLoader';
+import { createInstance, types as sdkTypes } from './util/sdkLoader';
 import { ClientApp, renderApp } from './app';
 import configureStore from './store';
 import { matchPathname } from './util/routes';
@@ -28,7 +28,7 @@ import { LoggingAnalyticsHandler, GoogleAnalyticsHandler } from './analytics/han
 
 import './marketplaceIndex.css';
 
-const { BigDecimal } = types;
+const { BigDecimal } = sdkTypes;
 
 const render = store => {
   // If the server already loaded the auth information, render the app
@@ -77,7 +77,7 @@ if (typeof window !== 'undefined') {
 
   // eslint-disable-next-line no-underscore-dangle
   const preloadedState = window.__PRELOADED_STATE__ || '{}';
-  const initialState = JSON.parse(preloadedState, types.reviver);
+  const initialState = JSON.parse(preloadedState, sdkTypes.reviver);
   const sdk = createInstance({
     clientId: config.sdk.clientId,
     baseUrl: config.sdk.baseUrl,
@@ -103,7 +103,7 @@ if (typeof window !== 'undefined') {
     window.app = {
       config,
       sdk,
-      sdkTypes: types,
+      sdkTypes,
       store,
       sample,
       routeConfiguration: routeConfiguration(),

--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -1,7 +1,9 @@
 import { has, trimEnd } from 'lodash';
 import Decimal from 'decimal.js';
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 import { subUnitDivisors } from './currencyConfig';
+
+const { Money } = sdkTypes;
 
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
@@ -201,7 +203,7 @@ const isGoogleMathLong = value => {
  * @return {Number} converted value
  */
 export const convertMoneyToNumber = value => {
-  if (!(value instanceof types.Money)) {
+  if (!(value instanceof Money)) {
     throw new Error('Value must be a Money type');
   }
   const subUnitDivisorAsDecimal = convertDivisorToDecimal(unitDivisor(value.currency));
@@ -238,7 +240,7 @@ export const convertMoneyToNumber = value => {
  * @return {String} formatted money value
  */
 export const formatMoney = (intl, value) => {
-  if (!(value instanceof types.Money)) {
+  if (!(value instanceof Money)) {
     throw new Error('Value must be a Money type');
   }
   const valueAsNumber = convertMoneyToNumber(value);

--- a/src/util/currency.test.js
+++ b/src/util/currency.test.js
@@ -1,5 +1,5 @@
 import Decimal from 'decimal.js';
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 import {
   MIN_SAFE_INTEGER,
   MAX_SAFE_INTEGER,
@@ -12,6 +12,8 @@ import {
   truncateToSubUnitPrecision,
   formatMoney,
 } from './currency';
+
+const { Money } = sdkTypes;
 
 describe('currency utils', () => {
   describe('isSafeNumber()', () => {
@@ -212,8 +214,6 @@ describe('currency utils', () => {
   });
 
   describe('convertMoneyToNumber(value)', () => {
-    const Money = types.Money;
-
     it('Money as value', () => {
       expect(convertMoneyToNumber(new Money(10, 'USD'))).toBeCloseTo(0.1);
       expect(convertMoneyToNumber(new Money(1000, 'USD'))).toBeCloseTo(10);

--- a/src/util/data.test.js
+++ b/src/util/data.test.js
@@ -1,4 +1,4 @@
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 import {
   combinedRelationships,
   combinedResourceObjects,
@@ -6,7 +6,7 @@ import {
   denormalisedEntities,
 } from './data';
 
-const { UUID } = types;
+const { UUID } = sdkTypes;
 
 describe('data utils', () => {
   describe('combinedRelationships()', () => {

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -20,7 +20,7 @@ import {
   ERROR_CODE_EMAIL_NOT_VERIFIED,
   ERROR_CODE_TOO_MANY_VERIFICATION_REQUESTS,
   ERROR_CODE_UPLOAD_OVER_LIMIT,
-} from './propTypes';
+} from './types';
 
 const errorAPIErrors = error => {
   return error && error.apiErrors ? error.apiErrors : [];
@@ -177,7 +177,7 @@ export const storableError = error => {
   // Status, statusText, and data.errors are (possibly) added to the error object by SDK
   const apiErrors = responseAPIErrors(error);
 
-  // Returned object is the same as prop type check in util/proptypes -> error
+  // Returned object is the same as prop type check in util/types -> error
   return {
     type: 'error',
     name,

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -1,6 +1,6 @@
-import { types } from '../util/sdkLoader';
+import { types as sdkTypes } from '../util/sdkLoader';
 
-const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = types;
+const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = sdkTypes;
 
 const placeOrigin = place => {
   if (place && place.geometry && place.geometry.location) {

--- a/src/util/routes.test.js
+++ b/src/util/routes.test.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { arrayOf } from 'prop-types';
 import { RoutesProvider } from '../components';
 import routeConfiguration from '../routeConfiguration';
 import { renderDeep, renderShallow } from './test-helpers';
-import * as propTypes from './propTypes';
 import { createResourceLocatorString, findRouteByRouteName, canonicalRoutePath } from './routes';
-
-const { arrayOf } = PropTypes;
 
 describe('util/routes.js', () => {
   describe('createResourceLocatorString', () => {

--- a/src/util/sample.js
+++ b/src/util/sample.js
@@ -1,13 +1,15 @@
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 
-export const marketplaceId = new types.UUID('16c6a4b8-88ee-429b-835a-6725206cd08c');
-export const userJoeId = new types.UUID('3c073fae-6172-4e75-8b92-f560d58cd47c');
-export const userJaneId = new types.UUID('7b98dd96-74c7-4ddc-9f46-38c0f91c4a19');
-export const listing1Id = new types.UUID('c6ff7190-bdf7-47a0-8a2b-e3136e74334f');
-export const listing2Id = new types.UUID('9009efe1-25ec-4ed5-9413-e80c584ff6bf');
-export const listing3Id = new types.UUID('8918693a-7a58-4d46-8324-f7996ef7579b');
-export const listing4Id = new types.UUID('5e1f2086-522c-46f3-87b4-451c6770c833');
-export const listing5Id = new types.UUID('f5130a7f-4b8b-453b-98e5-78e38ad02c3f');
-export const listing6Id = new types.UUID('927a30a2-3a69-4b0d-9c2e-a41744488703');
-export const image1Id = new types.UUID('4617c584-edfd-49e9-be43-2f1d50fb6e35');
-export const image2Id = new types.UUID('948b1926-67f9-402a-a7c7-f8ff3090c249');
+const { UUID } = sdkTypes;
+
+export const marketplaceId = new UUID('16c6a4b8-88ee-429b-835a-6725206cd08c');
+export const userJoeId = new UUID('3c073fae-6172-4e75-8b92-f560d58cd47c');
+export const userJaneId = new UUID('7b98dd96-74c7-4ddc-9f46-38c0f91c4a19');
+export const listing1Id = new UUID('c6ff7190-bdf7-47a0-8a2b-e3136e74334f');
+export const listing2Id = new UUID('9009efe1-25ec-4ed5-9413-e80c584ff6bf');
+export const listing3Id = new UUID('8918693a-7a58-4d46-8324-f7996ef7579b');
+export const listing4Id = new UUID('5e1f2086-522c-46f3-87b4-451c6770c833');
+export const listing5Id = new UUID('f5130a7f-4b8b-453b-98e5-78e38ad02c3f');
+export const listing6Id = new UUID('927a30a2-3a69-4b0d-9c2e-a41744488703');
+export const image1Id = new UUID('4617c584-edfd-49e9-be43-2f1d50fb6e35');
+export const image2Id = new UUID('948b1926-67f9-402a-a7c7-f8ff3090c249');

--- a/src/util/test-data.js
+++ b/src/util/test-data.js
@@ -1,11 +1,16 @@
 import Decimal from 'decimal.js';
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 import { nightsBetween } from '../util/dates';
-import * as propTypes from '../util/propTypes';
+import {
+  TX_TRANSITION_ACCEPT,
+  TX_TRANSITION_ACTOR_CUSTOMER,
+  TX_TRANSITION_ACTOR_PROVIDER,
+  TX_TRANSITION_PREAUTHORIZE,
+} from '../util/types';
 
-const { UUID, LatLng, Money } = types;
+const { UUID, LatLng, Money } = sdkTypes;
 
-// Create a booking that conforms to the util/propTypes booking schema
+// Create a booking that conforms to the util/types booking schema
 export const createBooking = (id, attributes = {}) => ({
   id: new UUID(id),
   type: 'booking',
@@ -16,7 +21,7 @@ export const createBooking = (id, attributes = {}) => ({
   },
 });
 
-// Create a user that conforms to the util/propTypes user schema
+// Create a user that conforms to the util/types user schema
 export const createUser = id => ({
   id: new UUID(id),
   type: 'user',
@@ -29,7 +34,7 @@ export const createUser = id => ({
   },
 });
 
-// Create a user that conforms to the util/propTypes currentUser schema
+// Create a user that conforms to the util/types currentUser schema
 export const createCurrentUser = id => ({
   id: new UUID(id),
   type: 'currentUser',
@@ -47,7 +52,7 @@ export const createCurrentUser = id => ({
   },
 });
 
-// Create a user that conforms to the util/propTypes user schema
+// Create a user that conforms to the util/types user schema
 export const createImage = id => ({
   id: new UUID(id),
   type: 'image',
@@ -69,7 +74,7 @@ export const createImage = id => ({
   },
 });
 
-// Create a user that conforms to the util/propTypes listing schema
+// Create a user that conforms to the util/types listing schema
 export const createListing = (id, attributes = {}, includes = {}) => ({
   id: new UUID(id),
   type: 'listing',
@@ -90,8 +95,8 @@ export const createListing = (id, attributes = {}, includes = {}) => ({
 export const createTxTransition = options => {
   return {
     at: new Date(Date.UTC(2017, 4, 1)),
-    by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-    transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+    by: TX_TRANSITION_ACTOR_CUSTOMER,
+    transition: TX_TRANSITION_PREAUTHORIZE,
     ...options,
   };
 };
@@ -99,7 +104,7 @@ export const createTxTransition = options => {
 export const createTransaction = options => {
   const {
     id,
-    lastTransition = propTypes.TX_TRANSITION_ACCEPT,
+    lastTransition = TX_TRANSITION_ACCEPT,
     total = new Money(1000, 'USD'),
     commission = new Money(100, 'USD'),
     booking = null,
@@ -111,13 +116,13 @@ export const createTransaction = options => {
     transitions = [
       createTxTransition({
         at: new Date(Date.UTC(2017, 4, 1)),
-        by: propTypes.TX_TRANSITION_ACTOR_CUSTOMER,
-        transition: propTypes.TX_TRANSITION_PREAUTHORIZE,
+        by: TX_TRANSITION_ACTOR_CUSTOMER,
+        transition: TX_TRANSITION_PREAUTHORIZE,
       }),
       createTxTransition({
         at: new Date(Date.UTC(2017, 5, 1)),
-        by: propTypes.TX_TRANSITION_ACTOR_PROVIDER,
-        transition: propTypes.TX_TRANSITION_ACCEPT,
+        by: TX_TRANSITION_ACTOR_PROVIDER,
+        transition: TX_TRANSITION_ACCEPT,
       }),
     ],
   } = options;

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -35,17 +35,19 @@ import { ensureTransaction } from './data';
 
 const { UUID, LatLng, LatLngBounds, Money } = sdkTypes;
 
+const propTypes = {};
+
 // Fixed value
-export const value = val => oneOf([val]);
+propTypes.value = val => oneOf([val]);
 
 // SDK type instances
-export const uuid = instanceOf(UUID);
-export const latlng = instanceOf(LatLng);
-export const latlngBounds = instanceOf(LatLngBounds);
-export const money = instanceOf(Money);
+propTypes.uuid = instanceOf(UUID);
+propTypes.latlng = instanceOf(LatLng);
+propTypes.latlngBounds = instanceOf(LatLngBounds);
+propTypes.money = instanceOf(Money);
 
 // Configuration for currency formatting
-export const currencyConfig = shape({
+propTypes.currencyConfig = shape({
   style: string.isRequired,
   currency: string.isRequired,
   currencyDisplay: string,
@@ -55,7 +57,7 @@ export const currencyConfig = shape({
 });
 
 // Configuration for a single route
-export const route = shape({
+propTypes.route = shape({
   name: string.isRequired,
   path: string.isRequired,
   exact: bool,
@@ -65,17 +67,17 @@ export const route = shape({
 });
 
 // Place object from LocationAutocompleteInput
-export const place = shape({
+propTypes.place = shape({
   address: string.isRequired,
-  origin: latlng.isRequired,
-  bounds: latlngBounds, // optional viewport bounds
+  origin: propTypes.latlng.isRequired,
+  bounds: propTypes.latlngBounds, // optional viewport bounds
   country: string, // country code, e.g. FI, US
 });
 
 // Denormalised image object
-export const image = shape({
-  id: uuid.isRequired,
-  type: value('image').isRequired,
+propTypes.image = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('image').isRequired,
   attributes: shape({
     sizes: arrayOf(
       shape({
@@ -89,9 +91,9 @@ export const image = shape({
 });
 
 // Denormalised user object
-export const currentUser = shape({
-  id: uuid.isRequired,
-  type: value('currentUser').isRequired,
+propTypes.currentUser = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('currentUser').isRequired,
   attributes: shape({
     banned: bool.isRequired,
     email: string.isRequired,
@@ -105,13 +107,13 @@ export const currentUser = shape({
     }).isRequired,
     stripeConnected: bool.isRequired,
   }),
-  profileImage: image,
+  profileImage: propTypes.image,
 });
 
 // Denormalised user object
-export const user = shape({
-  id: uuid.isRequired,
-  type: value('user').isRequired,
+propTypes.user = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('user').isRequired,
   attributes: shape({
     banned: bool.isRequired,
     profile: shape({
@@ -120,38 +122,38 @@ export const user = shape({
       bio: string,
     }),
   }),
-  profileImage: image,
+  profileImage: propTypes.image,
 });
 
 const listingAttributes = shape({
   title: string.isRequired,
   description: string.isRequired,
   address: string.isRequired,
-  geolocation: latlng.isRequired,
+  geolocation: propTypes.latlng.isRequired,
   closed: bool.isRequired,
-  deleted: value(false).isRequired,
-  price: money,
+  deleted: propTypes.value(false).isRequired,
+  price: propTypes.money,
   customAttributes: object,
 });
 
 const deletedListingAttributes = shape({
   closed: bool.isRequired,
-  deleted: value(true).isRequired,
+  deleted: propTypes.value(true).isRequired,
 });
 
 // Denormalised listing object
-export const listing = shape({
-  id: uuid.isRequired,
-  type: value('listing').isRequired,
+propTypes.listing = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('listing').isRequired,
   attributes: oneOfType([listingAttributes, deletedListingAttributes]).isRequired,
-  author: user,
-  images: arrayOf(image),
+  author: propTypes.user,
+  images: arrayOf(propTypes.image),
 });
 
 // Denormalised booking object
-export const booking = shape({
-  id: uuid.isRequired,
-  type: value('booking').isRequired,
+propTypes.booking = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('booking').isRequired,
   attributes: shape({
     end: instanceOf(Date).isRequired,
     start: instanceOf(Date).isRequired,
@@ -256,7 +258,8 @@ export const txHasFirstReview = tx => firstReviewTransitions.includes(txLastTran
 
 export const txIsReviewed = tx => areReviewsCompleted(txLastTransition(tx));
 
-export const txTransition = shape({
+// TODO: rename to `transition`
+propTypes.txTransition = shape({
   at: instanceOf(Date).isRequired,
   by: oneOf(TX_TRANSITION_ACTORS).isRequired,
   transition: oneOf(TX_TRANSITIONS).isRequired,
@@ -287,8 +290,8 @@ export const REVIEW_TYPE_OF_PROVIDER = 'ofProvider';
 export const REVIEW_TYPE_OF_CUSTOMER = 'ofCustomer';
 
 // A review on a user
-export const review = shape({
-  id: uuid.isRequired,
+propTypes.review = shape({
+  id: propTypes.uuid.isRequired,
   attributes: shape({
     at: instanceOf(Date).isRequired,
     content: string,
@@ -296,8 +299,8 @@ export const review = shape({
     state: string.isRequired,
     type: oneOf([REVIEW_TYPE_OF_PROVIDER, REVIEW_TYPE_OF_CUSTOMER]).isRequired,
   }).isRequired,
-  author: user,
-  subject: user,
+  author: propTypes.user,
+  subject: propTypes.user,
 });
 
 export const LINE_ITEM_NIGHT = 'line-item/night';
@@ -306,12 +309,12 @@ export const LINE_ITEM_PROVIDER_COMMISSION = 'line-item/provider-commission';
 
 const LINE_ITEMS = [LINE_ITEM_NIGHT, LINE_ITEM_DAY, LINE_ITEM_PROVIDER_COMMISSION];
 
-export const bookingUnitType = oneOf([LINE_ITEM_NIGHT, LINE_ITEM_DAY]);
+propTypes.bookingUnitType = oneOf([LINE_ITEM_NIGHT, LINE_ITEM_DAY]);
 
 // Denormalised transaction object
-export const transaction = shape({
-  id: uuid.isRequired,
-  type: value('transaction').isRequired,
+propTypes.transaction = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('transaction').isRequired,
   attributes: shape({
     createdAt: instanceOf(Date).isRequired,
     lastTransitionedAt: instanceOf(Date).isRequired,
@@ -319,41 +322,41 @@ export const transaction = shape({
 
     // An enquiry won't need a total sum nor a booking so these are
     // optional.
-    payinTotal: money,
-    payoutTotal: money,
+    payinTotal: propTypes.money,
+    payoutTotal: propTypes.money,
 
     lineItems: arrayOf(
       shape({
         code: oneOf(LINE_ITEMS).isRequired,
         includeFor: arrayOf(oneOf(['customer', 'provider'])).isRequired,
         quantity: instanceOf(Decimal),
-        unitPrice: money.isRequired,
-        lineTotal: money.isRequired,
+        unitPrice: propTypes.money.isRequired,
+        lineTotal: propTypes.money.isRequired,
         reversal: bool.isRequired,
       })
     ).isRequired,
-    transitions: arrayOf(txTransition).isRequired,
+    transitions: arrayOf(propTypes.txTransition).isRequired,
   }),
-  booking,
-  listing,
-  customer: user,
-  provider: user,
-  reviews: arrayOf(review),
+  booking: propTypes.booking,
+  listing: propTypes.listing,
+  customer: propTypes.user,
+  provider: propTypes.user,
+  reviews: arrayOf(propTypes.review),
 });
 
 // Denormalised transaction message
-export const message = shape({
-  id: uuid.isRequired,
-  type: value('message').isRequired,
+propTypes.message = shape({
+  id: propTypes.uuid.isRequired,
+  type: propTypes.value('message').isRequired,
   attributes: shape({
     at: instanceOf(Date).isRequired,
     content: string.isRequired,
   }).isRequired,
-  sender: user,
+  sender: propTypes.user,
 });
 
 // Pagination information in the response meta
-export const pagination = shape({
+propTypes.pagination = shape({
   page: number.isRequired,
   perPage: number.isRequired,
   totalItems: number.isRequired,
@@ -389,8 +392,8 @@ const ERROR_CODES = [
 
 // API error
 // TODO this is likely to change soonish
-export const apiError = shape({
-  id: uuid.isRequired,
+propTypes.apiError = shape({
+  id: propTypes.uuid.isRequired,
   status: number.isRequired,
   code: oneOf(ERROR_CODES).isRequired,
   title: string.isRequired,
@@ -398,11 +401,13 @@ export const apiError = shape({
 });
 
 // Storable error prop type. (Error object should not be stored as it is.)
-export const error = shape({
-  type: value('error').isRequired,
+propTypes.error = shape({
+  type: propTypes.value('error').isRequired,
   name: string.isRequired,
   message: string,
   status: number,
   statusText: string,
-  apiErrors: arrayOf(apiError),
+  apiErrors: arrayOf(propTypes.apiError),
 });
+
+export { propTypes };

--- a/src/util/urlHelpers.js
+++ b/src/util/urlHelpers.js
@@ -1,7 +1,7 @@
 import queryString from 'query-string';
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 
-const { LatLng, LatLngBounds } = types;
+const { LatLng, LatLngBounds } = sdkTypes;
 
 export const createSlug = str =>
   encodeURIComponent(

--- a/src/util/urlHelpers.test.js
+++ b/src/util/urlHelpers.test.js
@@ -1,4 +1,4 @@
-import { types } from './sdkLoader';
+import { types as sdkTypes } from './sdkLoader';
 import {
   parseFloatNum,
   encodeLatLng,
@@ -9,7 +9,7 @@ import {
   parse,
 } from './urlHelpers';
 
-const { LatLng, LatLngBounds } = types;
+const { LatLng, LatLngBounds } = sdkTypes;
 
 const SPACE = encodeURIComponent(' ');
 const COMMA = encodeURIComponent(',');


### PR DESCRIPTION
- Rename to types
- Collect propTypes within a named propTypes export
- Use named imports for easier refactoring and customisation later
- Rename sdk types to sdkTypes in imports to avoid confusion

## Changes to old conventions

Importing the `propTypes` to use in PropType validtion:

```diff
-import * as propTypes from '../../util/propTypes';
+import { propTypes } from '../../util/types';
```

Importing anything else:

```diff
-import * as propTypes from '../../util/propTypes';
+import { TX_TRANSITION_ACCEPT, txIsAccepted } from '../../util/types';

// Usage changes:

-if (propTypes.txIsAccepted(/* something */)) {
+if (txisAccepted(/* something */)) {

-if (tr === propTypes.TX_TRANSITION_ACCEPT) {
+if (tr === TX_TRANSITION_ACCEPT) {
```