### PR TITLE
Remove closed attribute from listing

### DIFF
--- a/src/components/TransactionPanel/__snapshots__/TransactionPanel.test.js.snap
+++ b/src/components/TransactionPanel/__snapshots__/TransactionPanel.test.js.snap
@@ -55,7 +55,6 @@ exports[`TransactionPanel - Order accepted matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -169,7 +168,6 @@ exports[`TransactionPanel - Order accepted matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -302,7 +300,6 @@ exports[`TransactionPanel - Order accepted matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -432,7 +429,6 @@ exports[`TransactionPanel - Order accepted matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -562,7 +558,6 @@ exports[`TransactionPanel - Order accepted matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -810,7 +805,6 @@ exports[`TransactionPanel - Order accepted matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -921,7 +915,6 @@ exports[`TransactionPanel - Order autodeclined matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -1035,7 +1028,6 @@ exports[`TransactionPanel - Order autodeclined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -1168,7 +1160,6 @@ exports[`TransactionPanel - Order autodeclined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -1298,7 +1289,6 @@ exports[`TransactionPanel - Order autodeclined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -1428,7 +1418,6 @@ exports[`TransactionPanel - Order autodeclined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -1676,7 +1665,6 @@ exports[`TransactionPanel - Order autodeclined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -1787,7 +1775,6 @@ exports[`TransactionPanel - Order canceled matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -1901,7 +1888,6 @@ exports[`TransactionPanel - Order canceled matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -2034,7 +2020,6 @@ exports[`TransactionPanel - Order canceled matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -2164,7 +2149,6 @@ exports[`TransactionPanel - Order canceled matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -2294,7 +2278,6 @@ exports[`TransactionPanel - Order canceled matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -2542,7 +2525,6 @@ exports[`TransactionPanel - Order canceled matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -2653,7 +2635,6 @@ exports[`TransactionPanel - Order declined matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -2767,7 +2748,6 @@ exports[`TransactionPanel - Order declined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -2900,7 +2880,6 @@ exports[`TransactionPanel - Order declined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -3030,7 +3009,6 @@ exports[`TransactionPanel - Order declined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -3160,7 +3138,6 @@ exports[`TransactionPanel - Order declined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -3408,7 +3385,6 @@ exports[`TransactionPanel - Order declined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -3519,7 +3495,6 @@ exports[`TransactionPanel - Order delivered matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -3633,7 +3608,6 @@ exports[`TransactionPanel - Order delivered matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -3766,7 +3740,6 @@ exports[`TransactionPanel - Order delivered matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -3896,7 +3869,6 @@ exports[`TransactionPanel - Order delivered matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -4026,7 +3998,6 @@ exports[`TransactionPanel - Order delivered matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -4274,7 +4245,6 @@ exports[`TransactionPanel - Order delivered matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -4385,7 +4355,6 @@ exports[`TransactionPanel - Order enquired matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -4499,7 +4468,6 @@ exports[`TransactionPanel - Order enquired matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -4632,7 +4600,6 @@ exports[`TransactionPanel - Order enquired matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -4762,7 +4729,6 @@ exports[`TransactionPanel - Order enquired matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -4892,7 +4858,6 @@ exports[`TransactionPanel - Order enquired matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -5140,7 +5105,6 @@ exports[`TransactionPanel - Order enquired matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -5251,7 +5215,6 @@ exports[`TransactionPanel - Order preauthorized matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -5365,7 +5328,6 @@ exports[`TransactionPanel - Order preauthorized matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -5498,7 +5460,6 @@ exports[`TransactionPanel - Order preauthorized matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -5628,7 +5589,6 @@ exports[`TransactionPanel - Order preauthorized matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -5758,7 +5718,6 @@ exports[`TransactionPanel - Order preauthorized matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -6006,7 +5965,6 @@ exports[`TransactionPanel - Order preauthorized matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -6111,7 +6069,6 @@ exports[`TransactionPanel - Sale accepted matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -6225,7 +6182,6 @@ exports[`TransactionPanel - Sale accepted matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -6345,7 +6301,6 @@ exports[`TransactionPanel - Sale accepted matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -6463,7 +6418,6 @@ exports[`TransactionPanel - Sale accepted matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -6581,7 +6535,6 @@ exports[`TransactionPanel - Sale accepted matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -6817,7 +6770,6 @@ exports[`TransactionPanel - Sale accepted matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -6909,7 +6861,6 @@ exports[`TransactionPanel - Sale autodeclined matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -7023,7 +6974,6 @@ exports[`TransactionPanel - Sale autodeclined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -7143,7 +7093,6 @@ exports[`TransactionPanel - Sale autodeclined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -7261,7 +7210,6 @@ exports[`TransactionPanel - Sale autodeclined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -7379,7 +7327,6 @@ exports[`TransactionPanel - Sale autodeclined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -7615,7 +7562,6 @@ exports[`TransactionPanel - Sale autodeclined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -7707,7 +7653,6 @@ exports[`TransactionPanel - Sale canceled matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -7821,7 +7766,6 @@ exports[`TransactionPanel - Sale canceled matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -7941,7 +7885,6 @@ exports[`TransactionPanel - Sale canceled matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -8059,7 +8002,6 @@ exports[`TransactionPanel - Sale canceled matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -8177,7 +8119,6 @@ exports[`TransactionPanel - Sale canceled matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -8413,7 +8354,6 @@ exports[`TransactionPanel - Sale canceled matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -8505,7 +8445,6 @@ exports[`TransactionPanel - Sale declined matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -8619,7 +8558,6 @@ exports[`TransactionPanel - Sale declined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -8739,7 +8677,6 @@ exports[`TransactionPanel - Sale declined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -8857,7 +8794,6 @@ exports[`TransactionPanel - Sale declined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -8975,7 +8911,6 @@ exports[`TransactionPanel - Sale declined matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -9211,7 +9146,6 @@ exports[`TransactionPanel - Sale declined matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -9303,7 +9237,6 @@ exports[`TransactionPanel - Sale delivered matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -9417,7 +9350,6 @@ exports[`TransactionPanel - Sale delivered matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -9537,7 +9469,6 @@ exports[`TransactionPanel - Sale delivered matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -9655,7 +9586,6 @@ exports[`TransactionPanel - Sale delivered matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -9773,7 +9703,6 @@ exports[`TransactionPanel - Sale delivered matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -10009,7 +9938,6 @@ exports[`TransactionPanel - Sale delivered matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -10101,7 +10029,6 @@ exports[`TransactionPanel - Sale enquired matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -10215,7 +10142,6 @@ exports[`TransactionPanel - Sale enquired matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -10335,7 +10261,6 @@ exports[`TransactionPanel - Sale enquired matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -10453,7 +10378,6 @@ exports[`TransactionPanel - Sale enquired matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -10571,7 +10495,6 @@ exports[`TransactionPanel - Sale enquired matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -10807,7 +10730,6 @@ exports[`TransactionPanel - Sale enquired matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -10899,7 +10821,6 @@ exports[`TransactionPanel - Sale preauthorized matches snapshot 1`] = `
         currentListing={
           Object {
             "attributes": Object {
-              "closed": false,
               "customAttributes": Object {},
               "deleted": false,
               "description": "listing1 description",
@@ -11013,7 +10934,6 @@ exports[`TransactionPanel - Sale preauthorized matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -11133,7 +11053,6 @@ exports[`TransactionPanel - Sale preauthorized matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -11251,7 +11170,6 @@ exports[`TransactionPanel - Sale preauthorized matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -11369,7 +11287,6 @@ exports[`TransactionPanel - Sale preauthorized matches snapshot 1`] = `
             },
             "listing": Object {
               "attributes": Object {
-                "closed": false,
                 "customAttributes": Object {},
                 "deleted": false,
                 "description": "listing1 description",
@@ -11605,7 +11522,6 @@ exports[`TransactionPanel - Sale preauthorized matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",

--- a/src/config.js
+++ b/src/config.js
@@ -225,7 +225,7 @@ const stripeSupportedCountries = [
 //    type: 'listing',
 //    attributes: {
 //      title: 'sauna',
-//      // and description, closed, deleted, price, etc.
+//      // and description, price, etc.
 //      customAttributes: {
 //        category: "mountain",
 //        // and other added custom attributes as "key: value" pairs

--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -347,6 +347,7 @@ export class ListingPageComponent extends Component {
     const userAndListingAuthorAvailable = !!(currentUser && authorAvailable);
     const isOwnListing =
       userAndListingAuthorAvailable && currentListing.author.id.uuid === currentUser.id.uuid;
+    const isClosed = currentListing.attributes.state === LISTING_STATE_CLOSED;
     const showContactUser = !currentUser || (currentUser && !isOwnListing);
 
     const currentAuthor = authorAvailable ? currentListing.author : null;
@@ -372,7 +373,7 @@ export class ListingPageComponent extends Component {
       </div>
     ) : null;
 
-    const showClosedListingHelpText = currentListing.id && currentListing.attributes.closed;
+    const showClosedListingHelpText = currentListing.id && isClosed;
     const bookingHeading = (
       <div className={css.bookingHeading}>
         <h2 className={css.bookingTitle}>
@@ -395,8 +396,8 @@ export class ListingPageComponent extends Component {
     };
 
     const handleBookingSubmit = values => {
-      const isClosed = currentListing.attributes.closed;
-      if (isOwnListing || isClosed) {
+      const isCurrentlyClosed = currentListing.attributes.state === LISTING_STATE_CLOSED;
+      if (isOwnListing || isCurrentlyClosed) {
         window.scrollTo(0, 0);
       } else {
         this.handleSubmit(values);
@@ -406,8 +407,8 @@ export class ListingPageComponent extends Component {
     const editParams = { id: listingId.uuid, slug: listingSlug, type: 'edit', tab: 'description' };
 
     const handleBookButtonClick = () => {
-      const isClosed = currentListing.attributes.closed;
-      if (isOwnListing || isClosed) {
+      const isCurrentlyClosed = currentListing.attributes.state === LISTING_STATE_CLOSED;
+      if (isOwnListing || isCurrentlyClosed) {
         window.scrollTo(0, 0);
       } else {
         gotoBookTab(history, currentListing);
@@ -634,7 +635,7 @@ export class ListingPageComponent extends Component {
                   </div>
 
                   {bookingHeading}
-                  {!currentListing.attributes.closed ? (
+                  {!isClosed ? (
                     <BookingDatesForm
                       className={css.bookingForm}
                       submitButtonWrapperClassName={css.bookingDatesSubmitButtonWrapper}
@@ -655,7 +656,7 @@ export class ListingPageComponent extends Component {
                     </div>
                   </div>
 
-                  {!currentListing.attributes.closed ? (
+                  {!isClosed ? (
                     <Button rootClassName={css.bookButton} onClick={handleBookButtonClick}>
                       {bookBtnMessage}
                     </Button>

--- a/src/containers/ListingPage/ListingPage.test.js
+++ b/src/containers/ListingPage/ListingPage.test.js
@@ -109,8 +109,6 @@ describe('ListingPage', () => {
   describe('ActionBarMaybe', () => {
     it('shows users own listing status', () => {
       const listing = createListing('listing-published', {
-        closed: false,
-        deleted: false,
         state: LISTING_STATE_PUBLISHED,
       });
       const actionBar = shallow(<ActionBarMaybe isOwnListing listing={listing} editParams={{}} />);
@@ -121,8 +119,6 @@ describe('ListingPage', () => {
     });
     it('shows users own pending listing status', () => {
       const listing = createListing('listing-published', {
-        closed: false,
-        deleted: false,
         state: LISTING_STATE_PENDING_APPROVAL,
       });
       const actionBar = shallow(<ActionBarMaybe isOwnListing listing={listing} editParams={{}} />);
@@ -133,8 +129,6 @@ describe('ListingPage', () => {
     });
     it('shows users own closed listing status', () => {
       const listing = createListing('listing-closed', {
-        closed: true,
-        deleted: false,
         state: LISTING_STATE_CLOSED,
       });
       const actionBar = shallow(<ActionBarMaybe isOwnListing listing={listing} editParams={{}} />);
@@ -145,8 +139,6 @@ describe('ListingPage', () => {
     });
     it('shows closed listing status', () => {
       const listing = createListing('listing-closed', {
-        closed: true,
-        deleted: false,
         state: LISTING_STATE_CLOSED,
       });
       const actionBar = shallow(
@@ -158,8 +150,6 @@ describe('ListingPage', () => {
     });
     it("is missing if listing is not closed or user's own", () => {
       const listing = createListing('listing-published', {
-        closed: false,
-        deleted: false,
         state: LISTING_STATE_PUBLISHED,
       });
       const actionBar = shallow(

--- a/src/containers/ListingPage/__snapshots__/ListingPage.test.js.snap
+++ b/src/containers/ListingPage/__snapshots__/ListingPage.test.js.snap
@@ -54,7 +54,6 @@ exports[`ListingPage matches snapshot 1`] = `
                 listing={
                   Object {
                     "attributes": Object {
-                      "closed": false,
                       "customAttributes": Object {},
                       "deleted": false,
                       "description": "listing1 description",

--- a/src/containers/TransactionPage/__snapshots__/TransactionPage.test.js.snap
+++ b/src/containers/TransactionPage/__snapshots__/TransactionPage.test.js.snap
@@ -148,7 +148,6 @@ exports[`TransactionPage - Order matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",
@@ -347,7 +346,6 @@ exports[`TransactionPage - Sale matches snapshot 1`] = `
               },
               "listing": Object {
                 "attributes": Object {
-                  "closed": false,
                   "customAttributes": Object {},
                   "deleted": false,
                   "description": "listing1 description",

--- a/src/util/test-data.js
+++ b/src/util/test-data.js
@@ -6,6 +6,7 @@ import {
   TRANSITION_REQUEST,
   TX_TRANSITION_ACTOR_CUSTOMER,
   TX_TRANSITION_ACTOR_PROVIDER,
+  LISTING_STATE_PUBLISHED,
 } from '../util/types';
 
 const { UUID, LatLng, Money } = sdkTypes;
@@ -82,9 +83,8 @@ export const createListing = (id, attributes = {}, includes = {}) => ({
     title: `${id} title`,
     description: `${id} description`,
     geolocation: new LatLng(40, 60),
-    closed: false,
     deleted: false,
-    state: 'published',
+    state: LISTING_STATE_PUBLISHED,
     price: new Money(5500, 'USD'),
     customAttributes: {},
     publicData: {},
@@ -101,9 +101,8 @@ export const createOwnListing = (id, attributes = {}, includes = {}) => ({
     title: `${id} title`,
     description: `${id} description`,
     geolocation: new LatLng(40, 60),
-    closed: false,
     deleted: false,
-    state: 'published',
+    state: LISTING_STATE_PUBLISHED,
     price: new Money(5500, 'USD'),
     customAttributes: {},
     publicData: {},

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -139,7 +139,6 @@ const listingAttributes = shape({
   title: string.isRequired,
   description: string.isRequired,
   geolocation: propTypes.latlng.isRequired,
-  closed: bool.isRequired,
   deleted: propTypes.value(false).isRequired,
   state: oneOf(LISTING_STATES).isRequired,
   price: propTypes.money,
@@ -151,7 +150,6 @@ const ownListingAttributes = shape({
   title: string.isRequired,
   description: string.isRequired,
   geolocation: propTypes.latlng.isRequired,
-  closed: bool.isRequired,
   deleted: propTypes.value(false).isRequired,
   state: oneOf(LISTING_STATES).isRequired,
   price: propTypes.money,
@@ -160,7 +158,6 @@ const ownListingAttributes = shape({
 });
 
 const deletedListingAttributes = shape({
-  closed: bool.isRequired,
   deleted: propTypes.value(true).isRequired,
 });
 


### PR DESCRIPTION
This PR removes any usage of the `closed` attribute in favor of the listing `state`.

Builds on top of #669, only the last commit is relevant to this PR.