### PR TITLE
Break long words on (Manage)ListingCards

### DIFF
--- a/src/components/ListingCard/ListingCard.js
+++ b/src/components/ListingCard/ListingCard.js
@@ -11,6 +11,8 @@ import config from '../../config';
 
 import css from './ListingCard.css';
 
+const MAX_LENGTH_FOR_WORDS_IN_TITLE = 10;
+
 const priceData = (price, intl) => {
   if (price && price.currency === config.currency) {
     const formattedPrice = formatMoney(intl, price);
@@ -28,6 +30,23 @@ const priceData = (price, intl) => {
     };
   }
   return {};
+};
+
+// Cards are not fixed sizes - So, long words in title make flexboxed items to grow too big.
+// 1. We split title to an array of words and spaces.
+//    "foo bar".split(/([^\s]+)/gi) => ["", "foo", " ", "bar", ""]
+// 2. Then we break long words by adding a '<span>' with word-break: 'break-all';
+const formatTitle = (title, maxLength) => {
+  const nonWhiteSpaceSequence = /([^\s]+)/gi;
+  return title.split(nonWhiteSpaceSequence).map((word, index) => {
+    return word.length > maxLength ? (
+      <span key={index} style={{ wordBreak: 'break-all' }}>
+        {word}
+      </span>
+    ) : (
+      word
+    );
+  });
 };
 
 export const ListingCardComponent = props => {
@@ -69,7 +88,7 @@ export const ListingCardComponent = props => {
           </div>
         </div>
         <div className={css.mainInfo}>
-          <div className={css.title}>{title}</div>
+          <div className={css.title}>{formatTitle(title, MAX_LENGTH_FOR_WORDS_IN_TITLE)}</div>
           <div className={css.authorInfo}>
             <FormattedMessage
               className={css.authorName}

--- a/src/components/ListingCard/__snapshots__/ListingCard.test.js.snap
+++ b/src/components/ListingCard/__snapshots__/ListingCard.test.js.snap
@@ -51,7 +51,9 @@ exports[`ListingCard matches snapshot 1`] = `
     </div>
     <div>
       <div>
-        listing1 title
+        listing1
+         
+        title
       </div>
       <div>
         <FormattedMessage

--- a/src/components/ManageListingCard/ManageListingCard.js
+++ b/src/components/ManageListingCard/ManageListingCard.js
@@ -27,6 +27,7 @@ import css from './ManageListingCard.css';
 
 // Menu content needs the same padding
 const MENU_CONTENT_OFFSET = -12;
+const MAX_LENGTH_FOR_WORDS_IN_TITLE = 7;
 
 const priceData = (price, intl) => {
   if (price && price.currency === config.currency) {
@@ -53,6 +54,23 @@ const createURL = (routes, listing) => {
   const pathParams = { id, slug, type: 'edit', tab: 'description' };
 
   return createResourceLocatorString('EditListingPage', routes, pathParams, {});
+};
+
+// Cards are not fixed sizes - So, long words in title make flexboxed items to grow too big.
+// 1. We split title to an array of words and spaces.
+//    "foo bar".split(/([^\s]+)/gi) => ["", "foo", " ", "bar", ""]
+// 2. Then we break long words by adding a '<span>' with word-break: 'break-all';
+const formatTitle = (title, maxLength) => {
+  const nonWhiteSpaceSequence = /([^\s]+)/gi;
+  return title.split(nonWhiteSpaceSequence).map((word, index) => {
+    return word.length > maxLength ? (
+      <span key={index} style={{ wordBreak: 'break-all' }}>
+        {word}
+      </span>
+    ) : (
+      word
+    );
+  });
 };
 
 export const ManageListingCardComponent = props => {
@@ -250,7 +268,7 @@ export const ManageListingCardComponent = props => {
           </div>
         </div>
         <div className={css.mainInfo}>
-          <div className={titleClasses}>{title}</div>
+          <div className={titleClasses}>{formatTitle(title, MAX_LENGTH_FOR_WORDS_IN_TITLE)}</div>
         </div>
         <button
           className={css.edit}

--- a/src/components/ManageListingCard/__snapshots__/ManageListingCard.test.js.snap
+++ b/src/components/ManageListingCard/__snapshots__/ManageListingCard.test.js.snap
@@ -135,7 +135,17 @@ exports[`ManageListingCard matches snapshot 1`] = `
       <div
         className=""
       >
-        listing1 title
+        <span
+          style={
+            Object {
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          listing1
+        </span>
+         
+        title
       </div>
     </div>
     <button


### PR DESCRIPTION
Discussion point:  
Should we make this a generic component? (There's now just 2 places where this is used.) 
```jsx
<StyledWords styler={(word, i) => (<span key={i}>{word}</span>)}>foo bar</StyledWords>
```
`/([^\s]+)/gi`:
![screen shot 2018-01-31 at 17 55 16](https://user-images.githubusercontent.com/717315/35632675-f40b0218-06af-11e8-96ef-7c6423b09286.png)
