### PR TITLE
Improve coordinate obfuscation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -241,18 +241,34 @@ const facebookAppId = null;
 const coordinates = {
   // If true, obfuscate the coordinates of the listings that are shown
   // on a map.
-  fuzzy: process.env.REACT_APP_FUZZY_COORDINATES || false,
+  fuzzy: false,
 
+  // Default zoom level when showing a single circle on a Map. Should
+  // be small enough so the whole circle fits in.
   fuzzyDefaultZoomLevel: 14,
 
-  // When fuzzy === true, a circle is shown on the map, the radius and
-  // the style can be configured here.
+  // When fuzzy === true, the coordinates on the Map component are
+  // obfuscated and a circle is shown instead of a marker. To decide a
+  // proper value for the offset and the radius, see:
+  //
+  // https://gis.stackexchange.com/a/8674
+
+  // Amount of maximum offset that is applied to obfuscate the
+  // original coordinates.
+  coordinateOffset: 0.004, // 0.001 is roughly 111m
+
+  // The circle radius in meters.
   circleRadius: 500,
+
+  // Options to style the circle appearance.
+  //
+  // See: https://developers.google.com/maps/documentation/javascript/reference#CircleOptions
   circleOptions: {
     fillColor: '#c0392b',
     fillOpacity: 0.2,
     strokeColor: '#c0392b',
     strokeWeight: 0.5,
+    clickable: false,
   },
 };
 

--- a/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
+++ b/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
@@ -156,12 +156,14 @@ exports[`SearchPageComponent matches snapshot 1`] = `
           coordinatesConfig={
             Object {
               "circleOptions": Object {
+                "clickable": false,
                 "fillColor": "#c0392b",
                 "fillOpacity": 0.2,
                 "strokeColor": "#c0392b",
                 "strokeWeight": 0.5,
               },
               "circleRadius": 500,
+              "coordinateOffset": 0.004,
               "fuzzy": false,
               "fuzzyDefaultZoomLevel": 14,
             }

--- a/src/util/maps.js
+++ b/src/util/maps.js
@@ -1,13 +1,14 @@
 import { random, memoize, round } from 'lodash';
 import { types as sdkTypes } from './sdkLoader';
+import config from '../config';
 
 const { LatLng } = sdkTypes;
 
 const obfuscatedCoordinatesImpl = latlng => {
   const { lat, lng } = latlng;
-  const threshold = 0.01;
-  const newLat = round(lat + random(-1 * threshold, threshold), 5);
-  const newLng = round(lng + random(-1 * threshold, threshold), 5);
+  const offset = config.coordinates.coordinateOffset;
+  const newLat = round(lat + random(-1 * offset, offset), 5);
+  const newLng = round(lng + random(-1 * offset, offset), 5);
   return new LatLng(newLat, newLng);
 };
 


### PR DESCRIPTION
This PR makes several improvements to the coordinate obfuscation:

- Remove option to turn on the functionality with an env var (unintuitive since required rebuild in Heroku, and local dev change anyways needed for the default value)
- Make coordinate offset configurable
- Make coordinate offset small enough that the original coordinates fit within the default circle radius
- Fix cursor changing when hovering on top of the circle
- Add documentation in the config file