### PR TITLE
Fix Mobile Safari: BookingDates inputs is overflowing

### DIFF
--- a/src/components/FieldDateRangeInput/FieldDateRangeInput.css
+++ b/src/components/FieldDateRangeInput/FieldDateRangeInput.css
@@ -73,17 +73,20 @@
  * but calendar popup doesn't.
  */
 .mobileMargins {
-  width: calc(100% - 48px);
+  /* Mobile Safari couldn't handle width: calc(100vw - 48px); */
+  width: calc(100vw - 48px);
   margin: 0 24px;
 
   /* Gutter between inputs (when calendar is not visible) */
   & .startDateLabel,
   & .endDateLabel {
-    flex-basis: calc(50% - 6px);
+    /* Mobile Safari couldn't handle width: calc(50% - 6px); */
+    flex-basis: calc(50vw - 30px);
   }
 
   & .input {
-    flex-basis: calc(50% - 6px);
+    /* Mobile Safari couldn't handle width: calc(50% - 6px); */
+    flex-basis: calc(50vw - 30px);
     transition: all 0.15s ease-out;
   }
 


### PR DESCRIPTION
Mobile Safari couldn't handle `width: calc(100% - 6px);`
- TODO: iPad might still have problems since this just fixes layout range: 0px - 767px
![6ad8016d-820c-4a35-b9e9-9c81ef86499a](https://user-images.githubusercontent.com/717315/35928970-1a2c698c-0c37-11e8-8763-a69a2fdacc19.jpeg)
