### PR TITLE
Increase filters mobile modal bottom padding

### DIFF
--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.css
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.css
@@ -96,8 +96,9 @@
 
 .filtersWrapper {
   /* add bottom margin so that the last filter won't be hidden
-   * under the bottom bar */
-  margin-bottom: 160px;
+   * under the mobile safari bottom bar or the "Show results"
+   * button bar */
+  padding-bottom: 180px;
 }
 
 .showListingsContainer {


### PR DESCRIPTION
Change the `margin-bottom` into a `padding-bottom` and increase it in order to mitigate the effects of the bottom bar in mobile Safati.