### PR TITLE
Sort search by distance (send origin optionally to API)

### DIFF
--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -226,8 +226,10 @@ class TopbarComponent extends Component {
     const { search, selectedPlace } = values.location;
     const { history } = this.props;
     const { origin, bounds, country } = selectedPlace;
-    const restParams = currentPage === 'SearchPage' ? parse(location.search) : {};
-    const searchParams = { ...restParams, address: search, origin, bounds, country };
+    const originMaybe = config.sortSearchByDistance ? { origin } : {};
+    const { origin: originInUrl, ...restParams } =
+      currentPage === 'SearchPage' ? parse(location.search) : {};
+    const searchParams = { ...restParams, ...originMaybe, address: search, bounds, country };
     history.push(createResourceLocatorString('SearchPage', routeConfiguration(), {}, searchParams));
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,9 @@ const i18n = {
   firstDayOfWeek: 0,
 };
 
+// Should search results be ordered by distance to origin.
+const sortSearchByDistance = true;
+
 // The transaction line item code for the main unit type in bookings.
 //
 // Possible values: ['line-item/night', 'line-item/day', 'line-item/units';]
@@ -280,6 +283,7 @@ const config = {
   bookingUnitType,
   i18n,
   sdk: { clientId: sdkClientId, baseUrl: sdkBaseUrl },
+  sortSearchByDistance,
   currency,
   currencyConfig,
   stripe: { publishableKey: stripePublishableKey, supportedCountries: stripeSupportedCountries },

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -86,9 +86,10 @@ const validURLParamsForExtendedData = params => {
 // extract search parameters, including a custom attribute named category
 const pickSearchParamsOnly = params => {
   const { address, origin, bounds, country, ...rest } = params || {};
+  const originMaybe = config.sortSearchByDistance ? { origin } : {};
   return {
-    origin,
     bounds,
+    ...originMaybe,
     ...validURLParamForExtendedData(CATEGORY_URL_PARAM, rest),
     ...validURLParamForExtendedData(AMENITIES_URL_PARAM, rest),
   };
@@ -164,10 +165,12 @@ export class SearchPageComponent extends Component {
     // or original location search is rendered once,
     // we start to react to 'bounds_changed' event by generating new searches
     if (viewportBoundsChanged && !this.modalOpenedBoundsChange) {
-      const origin = googleLatLngToSDKLatLng(viewportGMapBounds.getCenter());
+      const originMaybe = config.sortSearchByDistance
+        ? { origin: googleLatLngToSDKLatLng(viewportGMapBounds.getCenter()) }
+        : {};
       const searchParams = {
         address,
-        origin,
+        ...originMaybe,
         bounds: viewportBounds,
         country,
         mapSearch: true,
@@ -193,9 +196,11 @@ export class SearchPageComponent extends Component {
 
     const perPage = MAX_SEARCH_RESULT_PAGE_SIZE_ON_MAP;
     const page = 1;
-    const { address, country, ...rest } = searchInURL;
+    const { address, country, origin, ...rest } = searchInURL;
+    const originMaybe = config.sortSearchByDistance ? { origin } : {};
     const searchParamsForMapResults = {
       ...rest,
+      ...originMaybe,
       include: ['images'],
       page,
       perPage,
@@ -534,9 +539,11 @@ SearchPage.loadData = (params, search) => {
     latlng: ['origin'],
     latlngBounds: ['bounds'],
   });
-  const { page = 1, address, country, ...rest } = queryParams;
+  const { page = 1, address, country, origin, ...rest } = queryParams;
+  const originMaybe = config.sortSearchByDistance ? { origin } : {};
   return searchListings({
     ...rest,
+    ...originMaybe,
     page,
     perPage: RESULT_PAGE_SIZE,
     include: ['author', 'images'],


### PR DESCRIPTION
This helps to make a change between "only paginated listings on map" vs current "map show more listings than pagination".