### PR TITLE
Fix search params handling with Topbar

### DIFF
--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -222,14 +222,18 @@ class TopbarComponent extends Component {
   }
 
   handleSubmit(values) {
-    const { currentPage, location } = this.props;
+    const { currentSearchParams } = this.props;
     const { search, selectedPlace } = values.location;
     const { history } = this.props;
     const { origin, bounds, country } = selectedPlace;
     const originMaybe = config.sortSearchByDistance ? { origin } : {};
-    const { origin: originInUrl, ...restParams } =
-      currentPage === 'SearchPage' ? parse(location.search) : {};
-    const searchParams = { ...restParams, ...originMaybe, address: search, bounds, country };
+    const searchParams = {
+      ...currentSearchParams,
+      ...originMaybe,
+      address: search,
+      bounds,
+      country,
+    };
     history.push(createResourceLocatorString('SearchPage', routeConfiguration(), {}, searchParams));
   }
 

--- a/src/components/TopbarMobileMenu/TopbarMobileMenu.css
+++ b/src/components/TopbarMobileMenu/TopbarMobileMenu.css
@@ -115,3 +115,12 @@
   white-space: nowrap;
   color: var(--marketplaceColor);
 }
+
+.currentPage {
+  color: var(--matterColorDark);
+
+  /* black left border */
+  border-left: 5px solid black;
+  margin-left: -24px;
+  padding-left: 19px;
+}

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -260,6 +260,8 @@ export class SearchPageComponent extends Component {
       latlngBounds: ['bounds'],
     });
 
+    // urlQueryParams doesn't contain page specific url params
+    // like mapSearch, page or origin (origin depends on config.sortSearchByDistance)
     const urlQueryParams = pickSearchParamsOnly(searchInURL);
 
     // Page transition might initially use values from previous search
@@ -404,7 +406,11 @@ export class SearchPageComponent extends Component {
           mainEntity: [schemaMainEntity],
         }}
       >
-        <TopbarContainer className={topbarClasses} currentPage="SearchPage" />
+        <TopbarContainer
+          className={topbarClasses}
+          currentPage="SearchPage"
+          currentSearchParams={urlQueryParams}
+        />
         <div className={css.container}>
           <div className={css.searchResultContainer}>
             <SearchFilters

--- a/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
+++ b/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
@@ -19,6 +19,12 @@ exports[`SearchPageComponent matches snapshot 1`] = `
 >
   <withRouter(Connect(TopbarContainerComponent))
     currentPage="SearchPage"
+    currentSearchParams={
+      Object {
+        "bounds": undefined,
+        "origin": undefined,
+      }
+    }
   />
   <div>
     <div>

--- a/src/containers/TopbarContainer/TopbarContainer.js
+++ b/src/containers/TopbarContainer/TopbarContainer.js
@@ -13,6 +13,7 @@ export const TopbarContainerComponent = props => {
   const {
     authInProgress,
     currentPage,
+    currentSearchParams,
     currentUser,
     currentUserHasListings,
     currentUserHasOrders,
@@ -33,6 +34,7 @@ export const TopbarContainerComponent = props => {
     <Topbar
       authInProgress={authInProgress}
       currentPage={currentPage}
+      currentSearchParams={currentSearchParams}
       currentUser={currentUser}
       currentUserHasListings={currentUserHasListings}
       currentUserHasOrders={currentUserHasOrders}
@@ -53,6 +55,7 @@ export const TopbarContainerComponent = props => {
 
 TopbarContainerComponent.defaultProps = {
   currentPage: null,
+  currentSearchParams: null,
   currentUser: null,
   currentUserHasOrders: null,
   notificationCount: 0,
@@ -62,6 +65,7 @@ TopbarContainerComponent.defaultProps = {
 TopbarContainerComponent.propTypes = {
   authInProgress: bool.isRequired,
   currentPage: string,
+  currentSearchParams: object,
   currentUser: propTypes.currentUser,
   currentUserHasListings: bool.isRequired,
   currentUserHasOrders: bool,


### PR DESCRIPTION
Fixing:
- URL param: *page* is not passed to Topbar (to be used in new searches)
- URL param: *mapSearch* is not passed to Topbar (to be used in new searches)
- Didn't remove currentPage from Topbar, but ended up fixing TopbarMobileMenu to resemble Janne's design. (Although, with a bit hacky -24px)

That last fix will have a visible change:
![screen shot 2018-03-07 at 15 26 39](https://user-images.githubusercontent.com/717315/37094627-18b74d6a-221c-11e8-9bb6-04b150832e2b.png)
