### PR TITLE
Limit the number of images to 1

### DIFF
--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -205,6 +205,7 @@ export class SearchPageComponent extends Component {
       page,
       perPage,
       'fields.image': ['variants.landscape-crop', 'variants.landscape-crop2x'],
+      'limit.images': 1,
     };
     this.searchMapListingsInProgress = true;
 
@@ -554,6 +555,7 @@ SearchPage.loadData = (params, search) => {
     perPage: RESULT_PAGE_SIZE,
     include: ['author', 'images'],
     'fields.image': ['variants.landscape-crop', 'variants.landscape-crop2x'],
+    'limit.images': 1,
   });
 };
 


### PR DESCRIPTION
This PR uses the new backend feature that let's client to limit the number of relations.

This nicely cuts down the response size:

Before:

![screen shot 2018-03-08 at 13 36 42](https://user-images.githubusercontent.com/429876/37149691-a3156f8a-22d7-11e8-8f51-9b88e2f859fd.png)

After:

![screen shot 2018-03-08 at 13 24 53](https://user-images.githubusercontent.com/429876/37149710-aca92bcc-22d7-11e8-92aa-d6173d034a97.png)
