### PR TITLE
Refactor refund

### DIFF
--- a/src/components/BookingBreakdown/BookingBreakdown.js
+++ b/src/components/BookingBreakdown/BookingBreakdown.js
@@ -17,7 +17,9 @@ import LineItemBookingPeriod from './LineItemBookingPeriod';
 import LineItemUnitsMaybe from './LineItemUnitsMaybe';
 import LineItemSubTotalMaybe from './LineItemSubTotalMaybe';
 import LineItemCustomerCommissionMaybe from './LineItemCustomerCommissionMaybe';
+import LineItemCustomerCommissionRefundMaybe from './LineItemCustomerCommissionRefundMaybe';
 import LineItemProviderCommissionMaybe from './LineItemProviderCommissionMaybe';
+import LineItemProviderCommissionRefundMaybe from './LineItemProviderCommissionRefundMaybe';
 import LineItemRefundMaybe from './LineItemRefundMaybe';
 import LineItemTotalPrice from './LineItemTotalPrice';
 import css from './BookingBreakdown.css';
@@ -49,17 +51,29 @@ export const BookingBreakdownComponent = props => {
         userRole={userRole}
         intl={intl}
       />
+      <LineItemRefundMaybe transaction={transaction} unitType={unitType} intl={intl} />
+
       <LineItemCustomerCommissionMaybe
         transaction={transaction}
         isCustomer={isCustomer}
         intl={intl}
       />
+      <LineItemCustomerCommissionRefundMaybe
+        transaction={transaction}
+        isCustomer={isCustomer}
+        intl={intl}
+      />
+
       <LineItemProviderCommissionMaybe
         transaction={transaction}
         isProvider={isProvider}
         intl={intl}
       />
-      <LineItemRefundMaybe transaction={transaction} unitType={unitType} intl={intl} />
+      <LineItemProviderCommissionRefundMaybe
+        transaction={transaction}
+        isProvider={isProvider}
+        intl={intl}
+      />
 
       <hr className={css.totalDivider} />
       <LineItemTotalPrice transaction={transaction} isProvider={isProvider} intl={intl} />

--- a/src/components/BookingBreakdown/LineItemCustomerCommissionMaybe.js
+++ b/src/components/BookingBreakdown/LineItemCustomerCommissionMaybe.js
@@ -21,9 +21,6 @@ const LineItemStudioTimeCustomerCommissionMaybe = props => {
   const customerCommissionLineItem = transaction.attributes.lineItems.find(
     item => item.code === LINE_ITEM_CUSTOMER_COMMISSION && !item.reversal
   );
-  const commissionRefund = transaction.attributes.lineItems.find(
-    item => item.code === LINE_ITEM_CUSTOMER_COMMISSION && item.reversal
-  );
 
   // If commission is passed it will be shown as a fee already reduces from the total price
   let commissionItem = null;
@@ -38,7 +35,7 @@ const LineItemStudioTimeCustomerCommissionMaybe = props => {
     const commission = customerCommissionLineItem.lineTotal;
     const formattedCommission = commission ? formatMoney(intl, commission) : null;
 
-    commissionItem = commissionRefund ? null : (
+    commissionItem = (
       <div className={css.lineItem}>
         <span className={css.itemLabel}>
           <FormattedMessage id="BookingBreakdown.commission" />

--- a/src/components/BookingBreakdown/LineItemCustomerCommissionRefundMaybe.js
+++ b/src/components/BookingBreakdown/LineItemCustomerCommissionRefundMaybe.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FormattedMessage, intlShape } from 'react-intl';
+import { formatMoney } from '../../util/currency';
+import { propTypes, LINE_ITEM_CUSTOMER_COMMISSION } from '../../util/types';
+
+import css from './BookingBreakdown.css';
+
+const LineItemCustomerCommissionRefundMaybe = props => {
+  const { transaction, isCustomer, intl } = props;
+
+  const refund = transaction.attributes.lineItems.find(
+    item => item.code === LINE_ITEM_CUSTOMER_COMMISSION && item.reversal
+  );
+
+  return isCustomer && refund ? (
+    <div className={css.lineItem}>
+      <span className={css.itemLabel}>
+        <FormattedMessage id="BookingBreakdown.refundCustomerFee" />
+      </span>
+      <span className={css.itemValue}>{formatMoney(intl, refund.lineTotal)}</span>
+    </div>
+  ) : null;
+};
+
+LineItemCustomerCommissionRefundMaybe.propTypes = {
+  transaction: propTypes.transaction.isRequired,
+  intl: intlShape.isRequired,
+};
+
+export default LineItemCustomerCommissionRefundMaybe;

--- a/src/components/BookingBreakdown/LineItemProviderCommissionMaybe.js
+++ b/src/components/BookingBreakdown/LineItemProviderCommissionMaybe.js
@@ -25,9 +25,6 @@ const LineItemProviderCommissionMaybe = props => {
   const providerCommissionLineItem = transaction.attributes.lineItems.find(
     item => item.code === LINE_ITEM_PROVIDER_COMMISSION && !item.reversal
   );
-  const commissionRefund = transaction.attributes.lineItems.find(
-    item => item.code === LINE_ITEM_PROVIDER_COMMISSION && item.reversal
-  );
 
   // If commission is passed it will be shown as a fee already reduces from the total price
   let commissionItem = null;
@@ -42,7 +39,7 @@ const LineItemProviderCommissionMaybe = props => {
     const commission = providerCommissionLineItem.lineTotal;
     const formattedCommission = commission ? formatMoney(intl, commission) : null;
 
-    commissionItem = commissionRefund ? null : (
+    commissionItem = (
       <div className={css.lineItem}>
         <span className={css.itemLabel}>
           <FormattedMessage id="BookingBreakdown.commission" />

--- a/src/components/BookingBreakdown/LineItemProviderCommissionRefundMaybe.js
+++ b/src/components/BookingBreakdown/LineItemProviderCommissionRefundMaybe.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FormattedMessage, intlShape } from 'react-intl';
+import { formatMoney } from '../../util/currency';
+import { propTypes, LINE_ITEM_PROVIDER_COMMISSION } from '../../util/types';
+
+import css from './BookingBreakdown.css';
+
+const LineItemProviderCommissionRefundMaybe = props => {
+  const { transaction, isProvider, intl } = props;
+
+  const refund = transaction.attributes.lineItems.find(
+    item => item.code === LINE_ITEM_PROVIDER_COMMISSION && item.reversal
+  );
+
+  return isProvider && refund ? (
+    <div className={css.lineItem}>
+      <span className={css.itemLabel}>
+        <FormattedMessage id="BookingBreakdown.refundProviderFee" />
+      </span>
+      <span className={css.itemValue}>{formatMoney(intl, refund.lineTotal)}</span>
+    </div>
+  ) : null;
+};
+
+LineItemProviderCommissionRefundMaybe.propTypes = {
+  transaction: propTypes.transaction.isRequired,
+  intl: intlShape.isRequired,
+};
+
+export default LineItemProviderCommissionRefundMaybe;

--- a/src/components/BookingBreakdown/__snapshots__/BookingBreakdown.test.js.snap
+++ b/src/components/BookingBreakdown/__snapshots__/BookingBreakdown.test.js.snap
@@ -202,6 +202,38 @@ exports[`BookingBreakdown provider canceled transaction data matches snapshot 1`
       -20
     </span>
   </div>
+  <div
+    className={undefined}
+  >
+    <span
+      className={undefined}
+    >
+      <span>
+        BookingBreakdown.commission
+      </span>
+    </span>
+    <span
+      className={undefined}
+    >
+      -2
+    </span>
+  </div>
+  <div
+    className={undefined}
+  >
+    <span
+      className={undefined}
+    >
+      <span>
+        BookingBreakdown.refundProviderFee
+      </span>
+    </span>
+    <span
+      className={undefined}
+    >
+      2
+    </span>
+  </div>
   <hr
     className={undefined}
   />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -52,6 +52,8 @@
   "BookingBreakdown.quantity": "{quantity, number} {quantity, plural, one {person} other {persons}}",
   "BookingBreakdown.quantityUnit": "Number of persons",
   "BookingBreakdown.refund": "Refund",
+  "BookingBreakdown.refundCustomerFee": "Refund Saunatime fee",
+  "BookingBreakdown.refundProviderFee": "Refund Saunatime fee",
   "BookingBreakdown.subTotal": "Subtotal",
   "BookingBreakdown.total": "Total price",
   "BookingDatesForm.bookingEndTitle": "End date",


### PR DESCRIPTION
I decided that it's not a good thing to calculate total refund on Frontend.
=> Both subtotal and commission have their own refund lines (provider and customer respectively.)

**Customer:**
![screen shot 2018-03-12 at 18 50 05](https://user-images.githubusercontent.com/717315/37298181-522662e2-2628-11e8-8dad-7cdc38e7424b.png)
![screen shot 2018-03-12 at 18 50 16](https://user-images.githubusercontent.com/717315/37298182-52918464-2628-11e8-860a-bc0b9bbf4879.png)
![screen shot 2018-03-12 at 18 49 12](https://user-images.githubusercontent.com/717315/37298179-51440f1e-2628-11e8-8a27-f94b072313b8.png)

**Provider:**
![screen shot 2018-03-12 at 18 54 48](https://user-images.githubusercontent.com/717315/37298264-78e0c3d2-2628-11e8-88ad-f0c9b8e19a2b.png)
