### PR TITLE
Use basic auth only if there're env variables set

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -118,7 +118,13 @@ app.use(cookieParser());
 if (!dev) {
   const USERNAME = process.env.BASIC_AUTH_USERNAME;
   const PASSWORD = process.env.BASIC_AUTH_PASSWORD;
-  app.use(auth.basicAuth(USERNAME, PASSWORD));
+  const hasUsername = typeof USERNAME === 'string' && USERNAME.length > 0;
+  const hasPassword = typeof PASSWORD === 'string' && PASSWORD.length > 0;
+
+  // If BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD have been set - let's use them
+  if (hasUsername && hasPassword) {
+    app.use(auth.basicAuth(USERNAME, PASSWORD));
+  }
 }
 
 const noCacheHeaders = {


### PR DESCRIPTION
This also checks that variables are meaningful 
(I.e. if someone has just removed the variable string and forgot to press the actual 'x' button.)