### PR TITLE
Use http.Agent with keepalive set to true

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,8 @@ require('source-map-support').install();
 // Configure process.env with .env.* files
 require('./env').configureEnv();
 
+const http = require('http');
+const https = require('https');
 const express = require('express');
 const helmet = require('helmet');
 const compression = require('compression');
@@ -133,6 +135,13 @@ const noCacheHeaders = {
   'Cache-control': 'no-cache, no-store, must-revalidate',
 };
 
+// Instantiate HTTP(S) Agents with keepAlive set to true.
+// This will reduce the request time for consecutive requests by
+// reusing the existing TCP connection, thus eliminating the time used
+// for setting up new TCP connections.
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+
 app.get('*', (req, res) => {
   if (req.url.startsWith('/static/')) {
     // The express.static middleware only handles static resources
@@ -160,6 +169,8 @@ app.get('*', (req, res) => {
   const sdk = sharetribeSdk.createInstance({
     clientId: CLIENT_ID,
     baseUrl: BASE_URL,
+    httpAgent: httpAgent,
+    httpsAgent: httpsAgent,
     tokenStore,
     typeHandlers: [
       {


### PR DESCRIPTION
Instantiate HTTP(S) Agents with keepAlive set to `true`. This will reduce the request time for consecutive requests by reusing the existing TCP connection, thus eliminating the time used for setting up new TCP connections. Based on my testing, the reduced response time can be as much as 200ms.

The implementation uses Node.js's httpAgent. There seems to be also libraries like [agentkeepalive](https://github.com/node-modules/agentkeepalive/) that are compatible with httpAgent and add couple additional features. However, I didn't immediately get the feeling that we need those additional features, so I decided to go with the normal Node's httpAgent. Also, [this article](https://www.paypal-engineering.com/2014/04/01/outbound-ssl-performance-in-node-js/) implies that agentkeepalive is not necessary with newer Node versions.

**Siege testing:**

Command to run:

```
siege -c 5 -t 30S https://sharetribe-starter-app.herokuapp.com/s\?address\=New%20York%2C%20NY%2C%20USA\&bounds\=40.9175771%2C-73.7002721%2C40.4773991%2C-74.25908989999999\&country\=US
```

Without keepalive:

```
Lifting the server siege...
Transactions:            440 hits
Availability:         100.00 %
Elapsed time:          29.77 secs
Data transferred:         0.02 MB
Response time:            0.29 secs
Transaction rate:        14.78 trans/sec
Throughput:           0.00 MB/sec
Concurrency:            4.22
Successful transactions:         448
Failed transactions:             0
Longest transaction:          1.33
Shortest transaction:         0.25

Lifting the server siege...
Transactions:            450 hits
Availability:         100.00 %
Elapsed time:          29.72 secs
Data transferred:         0.02 MB
Response time:            0.28 secs
Transaction rate:        15.14 trans/sec
Throughput:           0.00 MB/sec
Concurrency:            4.27
Successful transactions:         454
Failed transactions:             0
Longest transaction:          1.34
Shortest transaction:         0.24

Lifting the server siege...
Transactions:            440 hits
Availability:         100.00 %
Elapsed time:          29.11 secs
Data transferred:         0.02 MB
Response time:            0.28 secs
Transaction rate:        15.12 trans/sec
Throughput:           0.00 MB/sec
Concurrency:            4.26
Successful transactions:         444
Failed transactions:             0
Longest transaction:          1.33
Shortest transaction:         0.24
```

With keepalive:

```
Lifting the server siege...
Transactions:            460 hits
Availability:         100.00 %
Elapsed time:          29.53 secs
Data transferred:         0.02 MB
Response time:            0.27 secs
Transaction rate:        15.58 trans/sec
Throughput:           0.00 MB/sec
Concurrency:            4.24
Successful transactions:         463
Failed transactions:             0
Longest transaction:          1.33
Shortest transaction:         0.25

Lifting the server siege...
Transactions:            440 hits
Availability:         100.00 %
Elapsed time:          29.56 secs
Data transferred:         0.02 MB
Response time:            0.28 secs
Transaction rate:        14.88 trans/sec
Throughput:           0.00 MB/sec
Concurrency:            4.21
Successful transactions:         455
Failed transactions:             0
Longest transaction:          1.43
Shortest transaction:         0.24

Lifting the server siege...
Transactions:            460 hits
Availability:         100.00 %
Elapsed time:          29.62 secs
Data transferred:         0.02 MB
Response time:            0.28 secs
Transaction rate:        15.53 trans/sec
Throughput:           0.00 MB/sec
Concurrency:            4.30
Successful transactions:         463
Failed transactions:             0
Longest transaction:          1.33
Shortest transaction:         0.25
```

**Browser testing**

URL to access: https://sharetribe-starter-app.herokuapp.com/s?address=New%20York%2C%20NY%2C%20USA&bounds=40.9175771%2C-73.7002721%2C40.4773991%2C-74.25908989999999&country=US

Without keepalive:

<img width="920" alt="screen shot 2018-03-17 at 11 46 44" src="https://user-images.githubusercontent.com/429876/37554471-dac79adc-29e1-11e8-89a6-8c1645291853.png">

<img width="923" alt="screen shot 2018-03-17 at 12 42 05" src="https://user-images.githubusercontent.com/429876/37554473-e149f94a-29e1-11e8-9fd2-dcf45dac3191.png">

**Perf test analysis:**

There seems to be significant improvements in the response time when accessing the page from browser. The improvements with `siege` testing were very small. I'm not exactly sure why the improvements with siege were so small, but I'm guessing that with different siege parameters we could have seen bigger improvements. Since the siege was hammering the server with 5 concurrent requests, maybe the bottleneck was somewhere else than in TCP connection creation? However, I believe that the browser testing results are more important, because the browser testing corresponds the normal usage pattern closer than hammering the server with siege.
