### PR TITLE
Revert "Revert "onIdle should not be called without ref to actual map""

### DIFF
--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -268,7 +268,9 @@ export class SearchMapComponent extends Component {
         onListingClicked={this.onListingClicked}
         onMapLoad={this.onMapLoadHandler}
         onIdle={() => {
-          onIdle(this.googleMap);
+          if (this.googleMap) {
+            onIdle(this.googleMap);
+          }
         }}
         onCloseAsModal={() => {
           if (onCloseAsModal) {


### PR DESCRIPTION
There wasn't any strange white-space bug or something like that - just Heroku deploys are down...

Reverts sharetribe/sharetribe-starter-app#771