### PR TITLE
Add support for configuring a minimum price for a listing

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,10 @@ const sdkBaseUrl = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
 
 const currency = process.env.REACT_APP_SHARETRIBE_MARKETPLACE_CURRENCY;
 
+// Listing minimum price in currency sub units, e.g. cents.
+// 0 means no restriction to the price
+const listingMinimumPriceSubUnits = 0;
+
 // Sentry DSN (Data Source Name), a client key for authenticating calls to Sentry
 const sentryDsn = process.env.REACT_APP_PUBLIC_SENTRY_DSN;
 
@@ -283,6 +287,7 @@ const config = {
   sdk: { clientId: sdkClientId, baseUrl: sdkBaseUrl },
   sortSearchByDistance,
   currency,
+  listingMinimumPriceSubUnits,
   currencyConfig,
   stripe: { publishableKey: stripePublishableKey, supportedCountries: stripeSupportedCountries },
   canonicalRootURL,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -163,6 +163,7 @@
   "EditListingPricingForm.priceInputPlaceholder": "Choose your price…",
   "EditListingPricingForm.pricePerUnit": "Price per night in euros",
   "EditListingPricingForm.priceRequired": "You need to add a valid price.",
+  "EditListingPricingForm.priceTooLow": "Price should be at least {minPrice}.",
   "EditListingPricingForm.updateFailed": "Failed to update listing. Please try again.",
   "EditListingPricingPanel.createListingTitle": "How much does it cost?",
   "EditListingPricingPanel.listingPriceCurrencyInvalid": "Listing currency is different from the marketplace currency. You cannot edit the price.",

--- a/src/util/validators.js
+++ b/src/util/validators.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
-import { types } from 'sharetribe-sdk';
+import { types as sdkTypes } from './sdkLoader';
 import { toPairs } from 'lodash';
 
-const { LatLng } = types;
+const { LatLng, Money } = sdkTypes;
 
 export const PASSWORD_MIN_LENGTH = 8;
 export const PASSWORD_MAX_LENGTH = 256;
@@ -108,6 +108,10 @@ const EMAIL_RE = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
 export const emailFormatValid = message => value => {
   return value && EMAIL_RE.test(value) ? VALID : message;
+};
+
+export const moneySubUnitAmountAtLeast = (message, minValue) => value => {
+  return value instanceof Money && value.amount >= minValue ? VALID : message;
 };
 
 export const ageAtLeast = (message, minYears) => value => {

--- a/src/util/validators.test.js
+++ b/src/util/validators.test.js
@@ -1,4 +1,13 @@
-import { required, requiredStringNoTrim, minLength, maxLength } from './validators';
+import { types as sdkTypes } from './sdkLoader';
+import {
+  required,
+  requiredStringNoTrim,
+  minLength,
+  maxLength,
+  moneySubUnitAmountAtLeast,
+} from './validators';
+
+const { Money } = sdkTypes;
 
 describe('validators', () => {
   describe('required()', () => {
@@ -118,6 +127,25 @@ describe('validators', () => {
     });
     it('should not allow too long array', () => {
       expect(maxLength('fail', 3)([1, 2, 3, 4])).toEqual('fail');
+    });
+  });
+  describe('moneySubUnitAmountAtLeast()', () => {
+    it('should not allow empty or missing value', () => {
+      expect(moneySubUnitAmountAtLeast('fail', 50)(undefined)).toEqual('fail');
+      expect(moneySubUnitAmountAtLeast('fail', 50)(null)).toEqual('fail');
+      expect(moneySubUnitAmountAtLeast('fail', 50)('')).toEqual('fail');
+      expect(moneySubUnitAmountAtLeast('fail', 50)(0)).toEqual('fail');
+      expect(moneySubUnitAmountAtLeast('fail', 50)(50)).toEqual('fail');
+      expect(moneySubUnitAmountAtLeast('fail', 50)(100)).toEqual('fail');
+    });
+    it('should not allow too low values', () => {
+      expect(moneySubUnitAmountAtLeast('fail', 50)(new Money(0, 'USD'))).toEqual('fail');
+      expect(moneySubUnitAmountAtLeast('fail', 50)(new Money(49, 'USD'))).toEqual('fail');
+    });
+    it('should allow large enough values', () => {
+      expect(moneySubUnitAmountAtLeast('fail', 0)(new Money(0, 'USD'))).toBeUndefined();
+      expect(moneySubUnitAmountAtLeast('fail', 50)(new Money(50, 'USD'))).toBeUndefined();
+      expect(moneySubUnitAmountAtLeast('fail', 50)(new Money(100, 'USD'))).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
This PR implements an optional minimum price configuration for a listing. If the `listingMinimumPriceSubUnits` config option is `0` (as it is by default), the validator is disabled.

## Screenshot

![screen shot 2018-03-28 at 16 34 37](https://user-images.githubusercontent.com/53923/38032307-fd56943c-32a5-11e8-9228-a46de92ca7e0.png)
