### PR TITLE
Add initial version of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+We are not following semantic versioning in this template app since any change could potentially be
+a breaking change for forked customization projects. We are still experimenting with what is a good
+way to update this template, but currently, we follow a pattern:
+
+* Major version change (v**X**.0.0): Changes to several pages and other components. Consider
+  implementing this without merging upstream (we'll provide instructions).
+* Minor version change (v0.**X**.0): New features and changes to a single page. These are likely to
+  cause conflicts.
+* Patch (v0.0.**X**): Bug fixes and small changes to components.
+
+## v0.2.0
+
+* Starting a change log for Flex Template for Web


### PR DESCRIPTION
Initial version of CHANGELOG.md

Before releasing v1.0.0 we should
- [ ] Convert remaining forms to Final Form (from buggy Redux Form)
- [ ] Change Stripe account creation process (current one is deprecated)
- [x] Change image upload endpoints (current ones are deprecated)
- [x] Change API error keys to camelCase (for Stripe errors)