### PR TITLE
Change Stripe errors to use camelCased info instead of snake_case

### DIFF
--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -388,7 +388,7 @@ export const createStripeAccount = payoutDetails => (dispatch, getState, sdk) =>
       dispatch(stripeAccountCreateError(e));
       const stripeMessage =
         e.apiErrors && e.apiErrors.length > 0 && e.apiErrors[0].meta
-          ? e.apiErrors[0].meta.stripe_message
+          ? e.apiErrors[0].meta.stripeMessage
           : null;
       log.error(err, 'create-stripe-account-failed', { stripeMessage });
       throw e;

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -115,7 +115,7 @@ export const isTransactionInitiateAmountTooLowError = error => {
     try {
       // TODO: This is a temporary solution until a proper error code
       // for this specific error is received in the response.
-      const msg = apiError.meta.stripe_message;
+      const msg = apiError.meta.stripeMessage;
       isAmountTooLow =
         msg.startsWith('Amount must be at least') ||
         msg.startsWith('Amount must convert to at least');
@@ -168,7 +168,7 @@ export const isStripeInvalidPostalCode = error => {
   return errorAPIErrors(error).some(apiError => {
     // Stripe doesn't seem to give an error code for this specific
     // case, so we have to recognize it from the message.
-    const msg = apiError.meta && apiError.meta.stripe_message ? apiError.meta.stripe_message : '';
+    const msg = apiError.meta && apiError.meta.stripeMessage ? apiError.meta.stripeMessage : '';
     return msgRe.test(msg);
   });
 };


### PR DESCRIPTION
Using:
stripeCode
stripeDeclineCode
stripeMessage

Instead of:
stripe_code
stripe_decline_code
stripe_message
