### PR TITLE
Hot fix replace '<' with unicode equivalent from script tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v3.6.1] 2019-11-04
+
+- [fix] Fix XSS-vulnerability on SearchPage where URL param 'address' was exposed directly to
+  schema, which is just a script tag: <script type="application/ld+json">. On server-side, this
+  could leak malformed HTML through to browsers and made it possible to inject own script tags.
+
+However, CSP prevents any data breach: injected js can't send data to unknonwn 3rd party sites.
+
+NOTE: Check that `REACT_APP_CSP` is in block mode on your production environment. You can read more
+from Flex docs: https://www.sharetribe.com/docs/guides/how-to-set-up-csp-for-ftw/
+[#1233](https://github.com/sharetribe/flex-template-web/pull/1233)
+
 - [change] Rename repository form `flex-template-web` to `ftw-daily`.
   [#1230](https://github.com/sharetribe/flex-template-web/pull/1230)
 

--- a/ext/transaction-process/README.md
+++ b/ext/transaction-process/README.md
@@ -1,7 +1,12 @@
 # Transaction process
 
-This is the transaction process that the Flex Template for Web is designed to work with by default. The `process.edn` file describes the process flow while the `templates` folder contains notification messages that are used by the process.
+This is the transaction process that the Flex Template for Web is designed to work with by default.
+The `process.edn` file describes the process flow while the `templates` folder contains notification
+messages that are used by the process.
 
-The process uses day-based booking and night-based pricing i.e. the quantity of booked units is defined by the number of nights in the booking. The process has preauthorization and it relies on the provider to accept booking requests.
+The process uses day-based booking and night-based pricing i.e. the quantity of booked units is
+defined by the number of nights in the booking. The process has preauthorization and it relies on
+the provider to accept booking requests.
 
-For different process descriptions for varying booking and pricing models, see the [Flex example processes repository](https://github.com/sharetribe/flex-example-processes)
+For different process descriptions for varying booking and pricing models, see the
+[Flex example processes repository](https://github.com/sharetribe/flex-example-processes)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -197,7 +197,9 @@ class PageComponent extends Component {
           <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
           <meta httpEquiv="Content-Language" content={intl.locale} />
           {metaTags}
-          <script type="application/ld+json">{schemaArrayJSONString}</script>
+          <script type="application/ld+json">
+            {schemaArrayJSONString.replace(/</g, '\\u003c')}
+          </script>
         </Helmet>
         <CookieConsent />
         <div


### PR DESCRIPTION
Fix XSS-vulnerability on `SearchPage` where URL param 'address' was exposed directly to schema, which is just a script tag: `<script type="application/ld+json">`. On server-side, this could leak malformed HTML through to browsers and made it possible to inject own script tags.

However, CSP prevents any data breach: injected JS can't send data to unknonwn 3rd party sites.

**NOTE:** Check that `REACT_APP_CSP` is in block mode on your production environment. You can read more from Flex Docs: https://www.sharetribe.com/docs/guides/how-to-set-up-csp-for-ftw/