### PR TITLE
New minor release: v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v3.7.0] 2019-12-09
+
 - [change] Make it easier to reorder EditListingWizard tabs/panels.
   [#1240](https://github.com/sharetribe/ftw-daily/pull/1240)
 - [change] In `PayoutDetailsForm` show states (US and AU) and provinces (CA) in dropdown instead of
   input. Since November 18, 2019 Stripe has been validating these values (read more
   https://support.stripe.com/questions/connect-address-validation).
 - [add] Add IconEdit [#1237](https://github.com/sharetribe/ftw-daily/pull/1237)
+
+  [v3.7.0]: https://github.com/sharetribe/flex-template-web/compare/v3.6.1...v3.7.0
 
 ## [v3.6.1] 2019-11-26
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
- [change] Make it easier to reorder EditListingWizard tabs/panels. [#1240](https://github.com/sharetribe/ftw-daily/pull/1240)
- [change] In `PayoutDetailsForm` show states (US and AU) and provinces (CA) in dropdown instead of input. Since November 18, 2019 Stripe has been validating these values (read more https://support.stripe.com/questions/connect-address-validation). [#1232](https://github.com/sharetribe/ftw-daily/pull/1232)
- [add] Add IconEdit [#1237](https://github.com/sharetribe/ftw-daily/pull/1237)
