### PR TITLE
Update handlebars and serialize-javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] Add `handlebars` 4.5.3 and `serialize-javascript` 2.1.1 to resolutions in `package.json`.
+  [#1251](https://github.com/sharetribe/ftw-daily/pull/1251)
+
 ## [v4.1.0] 2020-02-03
 
 - [fix] Remove unused 'invalid' prop that breaks some versions of Final Form
@@ -21,6 +24,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] Fix `console.warn` functions. [#1252](https://github.com/sharetribe/ftw-daily/pull/1252)
 - [add] Add missing countries (e.g. MX and JP) to `StripeBankAccountTokenInput` validations.
   [#1250](https://github.com/sharetribe/ftw-daily/pull/1250)
+
+  [v4.0.1]: https://github.com/sharetribe/flex-template-web/compare/v4.0.0...v4.0.1
 
 ## [v4.0.0] 2019-12-19
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   "resolutions": {
     "react-dates/lodash": "^4.17.14",
     "react-google-maps/lodash": "^4.17.14",
-    "react-test-renderer": "^16.9.0"
+    "react-test-renderer": "^16.9.0",
+    "handlebars": "^4.5.3"
   },
   "nodemonConfig": {
     "execMap": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "react-dates/lodash": "^4.17.14",
     "react-google-maps/lodash": "^4.17.14",
     "react-test-renderer": "^16.9.0",
-    "handlebars": "^4.5.3"
+    "handlebars": "^4.5.3",
+    "serialize-javascript": "^2.1.1"
   },
   "nodemonConfig": {
     "execMap": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10034,10 +10034,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.8.0.tgz#9515fc687232e2321aea1ca7a529476eb34bb480"
-  integrity sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==
+serialize-javascript@^1.7.0, serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-index@^1.7.2:
   version "1.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5025,10 +5025,10 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@^4.1.2, handlebars@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
Update handlebars and serialize-javascript because of security alerts.

These both should be internal dependencies of Create React App so when w update our CRA fork we should check if these resolutions could be removed. 

Related to https://github.com/sharetribe/ftw-daily/pull/1249 