### PR TITLE
Sort search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [add] Search result sorting [#1277](https://github.com/sharetribe/ftw-daily/pull/1277)
 - [change] Move category and amenities search filters from primary filters to secondary filters. [#1275](https://github.com/sharetribe/ftw-daily/pull/1275)
 
 ## [v4.3.0] 2020-03-16

--- a/src/components/SearchFilters/SearchFilters.css
+++ b/src/components/SearchFilters/SearchFilters.css
@@ -2,8 +2,13 @@
 
 .root {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   background-color: var(--matterColorBright);
+}
+
+.filterWrapper {
+  display: flex;
+  justify-content: space-between;
   position: relative;
 }
 
@@ -24,6 +29,8 @@
   line-height: 20px;
   margin-top: 9px;
   margin-bottom: 11px;
+  margin-left: auto;
+  margin-right: 8px;
 
   /* parent uses flexbox: this defines minimum width for text "6 results" */
   flex-basis: 55px;

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 import { withRouter } from 'react-router-dom';
 import omit from 'lodash/omit';
 
-import { BookingDateRangeFilter, PriceFilter, KeywordFilter } from '../../components';
+import config from '../../config';
+import { BookingDateRangeFilter, PriceFilter, KeywordFilter, SortBy } from '../../components';
 import routeConfiguration from '../../routeConfiguration';
 import { parseDateFromISO8601, stringifyDateToISO8601 } from '../../util/dates';
 import { createResourceLocatorString } from '../../util/routes';
@@ -53,6 +54,7 @@ const SearchFiltersComponent = props => {
     rootClassName,
     className,
     urlQueryParams,
+    sort,
     listingsAreLoaded,
     resultsCount,
     searchInProgress,
@@ -84,6 +86,8 @@ const SearchFiltersComponent = props => {
   const initialKeyword = keywordFilter
     ? initialValue(urlQueryParams, keywordFilter.paramName)
     : null;
+
+  const isKeywordFilterActive = !!initialKeyword;
 
   const handlePrice = (urlParam, range) => {
     const { minPrice, maxPrice } = range || {};
@@ -172,6 +176,25 @@ const SearchFiltersComponent = props => {
       />
     </button>
   ) : null;
+
+  const handleSortBy = (urlParam, values) => {
+    const queryParams = values
+      ? { ...urlQueryParams, [urlParam]: values }
+      : omit(urlQueryParams, urlParam);
+
+    history.push(createResourceLocatorString('SearchPage', routeConfiguration(), {}, queryParams));
+  };
+
+  const sortBy = config.custom.sortConfig.active ? (
+    <SortBy
+      sort={sort}
+      showAsPopup
+      isKeywordFilterActive={isKeywordFilterActive}
+      onSelect={handleSortBy}
+      contentPlacementOffset={FILTER_DROPDOWN_OFFSET}
+    />
+  ) : null;
+
   return (
     <div className={classes}>
       <div className={css.filters}>
@@ -180,6 +203,8 @@ const SearchFiltersComponent = props => {
         {keywordFilterElement}
         {toggleSearchFiltersPanelButton}
       </div>
+
+      {sortBy}
 
       {listingsAreLoaded && resultsCount > 0 ? (
         <div className={css.searchResultSummary}>

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -69,7 +69,7 @@ const SearchFiltersComponent = props => {
   } = props;
 
   const hasNoResult = listingsAreLoaded && resultsCount === 0;
-  const classes = classNames(rootClassName || css.root, { [css.longInfo]: hasNoResult }, className);
+  const classes = classNames(rootClassName || css.root, className);
 
   const keywordLabel = intl.formatMessage({
     id: 'SearchFilters.keywordLabel',
@@ -197,22 +197,23 @@ const SearchFiltersComponent = props => {
 
   return (
     <div className={classes}>
-      <div className={css.filters}>
-        {priceFilterElement}
-        {dateRangeFilterElement}
-        {keywordFilterElement}
-        {toggleSearchFiltersPanelButton}
-      </div>
-
-      {sortBy}
-
-      {listingsAreLoaded && resultsCount > 0 ? (
-        <div className={css.searchResultSummary}>
-          <span className={css.resultsFound}>
-            <FormattedMessage id="SearchFilters.foundResults" values={{ count: resultsCount }} />
-          </span>
+      <div className={css.filterWrapper}>
+        <div className={css.filters}>
+          {priceFilterElement}
+          {dateRangeFilterElement}
+          {keywordFilterElement}
+          {toggleSearchFiltersPanelButton}
         </div>
-      ) : null}
+
+        {listingsAreLoaded && resultsCount > 0 ? (
+          <div className={css.searchResultSummary}>
+            <span className={css.resultsFound}>
+              <FormattedMessage id="SearchFilters.foundResults" values={{ count: resultsCount }} />
+            </span>
+          </div>
+        ) : null}
+        {sortBy}
+      </div>
 
       {hasNoResult ? (
         <div className={css.noSearchResults}>

--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.js
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.js
@@ -5,6 +5,8 @@ import { FormattedMessage, injectIntl, intlShape } from '../../util/reactIntl';
 import { withRouter } from 'react-router-dom';
 import omit from 'lodash/omit';
 
+import config from '../../config';
+
 import routeConfiguration from '../../routeConfiguration';
 import { parseDateFromISO8601, stringifyDateToISO8601 } from '../../util/dates';
 import { createResourceLocatorString } from '../../util/routes';
@@ -15,6 +17,7 @@ import {
   PriceFilter,
   SelectSingleFilter,
   SelectMultipleFilter,
+  SortBy,
   BookingDateRangeFilter,
 } from '../../components';
 import { propTypes } from '../../util/types';
@@ -36,6 +39,7 @@ class SearchFiltersMobileComponent extends Component {
     this.handlePrice = this.handlePrice.bind(this);
     this.handleDateRange = this.handleDateRange.bind(this);
     this.handleKeyword = this.handleKeyword.bind(this);
+    this.handleSortBy = this.handleSortBy.bind(this);
     this.initialValue = this.initialValue.bind(this);
     this.initialValues = this.initialValues.bind(this);
     this.initialPriceRangeValue = this.initialPriceRangeValue.bind(this);
@@ -129,6 +133,15 @@ class SearchFiltersMobileComponent extends Component {
     history.push(createResourceLocatorString('SearchPage', routeConfiguration(), {}, queryParams));
   }
 
+  handleSortBy(urlParam, sort) {
+    const { urlQueryParams, history } = this.props;
+    const queryParams = urlParam
+      ? { ...urlQueryParams, [urlParam]: sort }
+      : omit(urlQueryParams, urlParam);
+
+    history.push(createResourceLocatorString('SearchPage', routeConfiguration(), {}, queryParams));
+  }
+
   // Reset all filter query parameters
   resetAll(e) {
     const { urlQueryParams, history, filterParamNames } = this.props;
@@ -185,6 +198,7 @@ class SearchFiltersMobileComponent extends Component {
     const {
       rootClassName,
       className,
+      sort,
       listingsAreLoaded,
       resultsCount,
       searchInProgress,
@@ -297,6 +311,16 @@ class SearchFiltersMobileComponent extends Component {
         />
       ) : null;
 
+    const isKeywordFilterActive = !!initialKeyword;
+
+    const sortBy = config.custom.sortConfig.active ? (
+      <SortBy
+        sort={sort}
+        isKeywordFilterActive={isKeywordFilterActive}
+        onSelect={this.handleSortBy}
+      />
+    ) : null;
+
     return (
       <div className={classes}>
         <div className={css.searchResultSummary}>
@@ -334,6 +358,7 @@ class SearchFiltersMobileComponent extends Component {
               {amenitiesFilterElement}
               {priceFilterElement}
               {dateRangeFilterElement}
+              {sortBy}
             </div>
           ) : null}
 
@@ -351,6 +376,7 @@ class SearchFiltersMobileComponent extends Component {
 SearchFiltersMobileComponent.defaultProps = {
   rootClassName: null,
   className: null,
+  sort: null,
   resultsCount: null,
   searchingInProgress: false,
   selectedFiltersCount: 0,
@@ -365,6 +391,7 @@ SearchFiltersMobileComponent.propTypes = {
   rootClassName: string,
   className: string,
   urlQueryParams: object.isRequired,
+  sort: string,
   listingsAreLoaded: bool.isRequired,
   resultsCount: number,
   searchingInProgress: bool,

--- a/src/components/SortBy/SortBy.js
+++ b/src/components/SortBy/SortBy.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { string, bool } from 'prop-types';
+import { intlShape, injectIntl } from '../../util/reactIntl';
+
+import config from '../../config';
+
+import SortByPlain from './SortByPlain';
+import SortByPopup from './SortByPopup';
+
+const SortBy = props => {
+  const { sort, showAsPopup, isKeywordFilterActive, intl, ...rest } = props;
+
+  const { relevanceKey } = config.custom.sortConfig;
+
+  const options = config.custom.sortConfig.options.map(option => {
+    const isRelevance = option.key === relevanceKey;
+    return {
+      ...option,
+      disabled: (isRelevance && !isKeywordFilterActive) || (!isRelevance && isKeywordFilterActive),
+    };
+  });
+  const defaultValue = 'createdAt';
+  const componentProps = {
+    urlParam: 'sort',
+    label: intl.formatMessage({ id: 'SortBy.heading' }),
+    options,
+    initialValue: isKeywordFilterActive ? relevanceKey : sort || defaultValue,
+    ...rest,
+  };
+  return showAsPopup ? <SortByPopup {...componentProps} /> : <SortByPlain {...componentProps} />;
+};
+
+SortBy.defaultProps = {
+  sort: null,
+  showAsPopup: false,
+};
+
+SortBy.propTypes = {
+  sort: string,
+  showAsPopup: bool,
+  isKeywordFilterActive: bool.isRequired,
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(SortBy);

--- a/src/components/SortBy/SortByPlain.css
+++ b/src/components/SortBy/SortByPlain.css
@@ -1,0 +1,102 @@
+@import '../../marketplace.css';
+
+.root {
+  padding-top: 24px;
+  padding-bottom: 17px;
+  border-bottom: 1px solid var(--matterColorNegative);
+}
+
+.filterLabel,
+.filterLabelSelected {
+  @apply --marketplaceH3FontStyles;
+
+  /* Baseline adjustment for label text */
+  margin-top: 0;
+  margin-bottom: 12px;
+  padding: 4px 0 2px 0;
+}
+
+.filterLabel {
+  color: var(--matterColorDark);
+}
+
+.filterLabelSelected {
+  color: var(--marketplaceColor);
+}
+
+.labelButton {
+  /* Override button styles */
+  outline: none;
+  text-align: left;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.optionsContainerOpen {
+  height: auto;
+  padding-bottom: 30px;
+}
+
+.optionsContainerClosed {
+  height: 0;
+  overflow: hidden;
+}
+
+.optionBorder,
+.optionBorderSelected {
+  position: absolute;
+  height: calc(100% - 12px);
+  top: 4px;
+  left: -24px;
+  transition: width var(--transitionStyleButton);
+}
+
+/* left animated "border" like hover element */
+.optionBorder {
+  width: 0;
+  background-color: var(--matterColorDark);
+}
+
+/* left static border for selected element */
+.optionBorderSelected {
+  width: 8px;
+  background-color: var(--matterColorDark);
+}
+
+.option {
+  @apply --marketplaceH4FontStyles;
+  font-weight: var(--fontWeightMedium);
+  font-size: 18px;
+  color: var(--matterColor);
+
+  /* Layout */
+  display: block;
+  position: relative;
+  margin: 0;
+  padding: 4px 0 8px 20px;
+
+  /* Override button styles */
+  outline: none;
+  border: none;
+  cursor: pointer;
+
+  &:focus,
+  &:hover {
+    color: var(--matterColorDark);
+  }
+
+  &:hover .menuItemBorder {
+    width: 6px;
+  }
+
+  &:disabled {
+    color: var(--matterColorAnti);
+    cursor: default;
+  }
+}
+
+.optionSelected {
+  composes: option;
+  color: var(--matterColorDark);
+}

--- a/src/components/SortBy/SortByPlain.js
+++ b/src/components/SortBy/SortByPlain.js
@@ -1,0 +1,98 @@
+import React, { Component } from 'react';
+import { arrayOf, func, shape, string } from 'prop-types';
+import classNames from 'classnames';
+
+import css from './SortByPlain.css';
+
+class SortByPlain extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { isOpen: true };
+    this.selectOption = this.selectOption.bind(this);
+    this.toggleIsOpen = this.toggleIsOpen.bind(this);
+  }
+
+  selectOption(option, e) {
+    const { urlParam, onSelect } = this.props;
+    onSelect(urlParam, option);
+
+    // blur event target if event is passed
+    if (e && e.currentTarget) {
+      e.currentTarget.blur();
+    }
+  }
+
+  toggleIsOpen() {
+    this.setState({ isOpen: !this.state.isOpen });
+  }
+
+  render() {
+    const { rootClassName, className, label, options, initialValue } = this.props;
+
+    const labelClass = initialValue ? css.filterLabelSelected : css.filterLabel;
+
+    const optionsContainerClass = classNames({
+      [css.optionsContainerOpen]: this.state.isOpen,
+      [css.optionsContainerClosed]: !this.state.isOpen,
+    });
+
+    const classes = classNames(rootClassName || css.root, className);
+
+    return (
+      <div className={classes}>
+        <div className={labelClass}>
+          <button className={css.labelButton} onClick={this.toggleIsOpen}>
+            <span className={labelClass}>{label}</span>
+          </button>
+        </div>
+        <div className={optionsContainerClass}>
+          {options.map(option => {
+            // check if this option is selected
+            const selected = initialValue === option.key;
+            const optionClass = selected ? css.optionSelected : css.option;
+            // menu item selected or border class
+            const optionBorderClass = classNames({
+              [css.optionBorderSelected]: selected,
+              [css.optionBorder]: !selected,
+            });
+            return (
+              <button
+                key={option.key}
+                className={optionClass}
+                disabled={option.disabled}
+                onClick={() => (selected ? null : this.selectOption(option.key))}
+              >
+                <span className={optionBorderClass} />
+                {option.longLabel || option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+}
+
+SortByPlain.defaultProps = {
+  rootClassName: null,
+  className: null,
+  initialValue: null,
+};
+
+SortByPlain.propTypes = {
+  rootClassName: string,
+  className: string,
+  urlParam: string.isRequired,
+  label: string.isRequired,
+  onSelect: func.isRequired,
+
+  options: arrayOf(
+    shape({
+      key: string.isRequired,
+      label: string.isRequired,
+    })
+  ).isRequired,
+  initialValue: string,
+};
+
+export default SortByPlain;

--- a/src/components/SortBy/SortByPopup.css
+++ b/src/components/SortBy/SortByPopup.css
@@ -1,13 +1,6 @@
 @import '../../marketplace.css';
 
 .root {
-  display: inline-block;
-  margin-left: auto;
-  margin-right: 8px;
-
-  &:last-of-type {
-    padding-right: 0;
-  }
 }
 
 .icon {
@@ -84,7 +77,6 @@
   color: var(--matterColor);
   margin-left: 30px;
   margin-right: 30px;
-  margin-bottom: 24px;
 }
 
 .menuItem {

--- a/src/components/SortBy/SortByPopup.css
+++ b/src/components/SortBy/SortByPopup.css
@@ -1,0 +1,150 @@
+@import '../../marketplace.css';
+
+.root {
+  display: inline-block;
+  margin-left: auto;
+  margin-right: 8px;
+
+  &:last-of-type {
+    padding-right: 0;
+  }
+}
+
+.icon {
+  position: relative;
+  font-size: 10px;
+  margin-right: 15px;
+  color: var(--matterColor);
+}
+
+.iconUp {
+  position: absolute;
+  left: 0;
+  top: -9px;
+}
+
+.iconDown {
+  position: absolute;
+  left: 0;
+  top: -0px;
+}
+
+.menuLabel {
+  @apply --marketplaceButtonStylesSecondary;
+  @apply --marketplaceSearchFilterLabelFontStyles;
+
+  padding: 9px 16px 10px 16px;
+  width: auto;
+  height: auto;
+  min-height: 0;
+  border-radius: 4px;
+
+  white-space: nowrap;
+
+  &:focus {
+    outline: none;
+    background-color: var(--matterColorLight);
+    border-color: transparent;
+    text-decoration: none;
+    box-shadow: var(--boxShadowFilterButton);
+  }
+}
+
+.menuContent {
+  margin-top: 7px;
+  padding-top: 13px;
+  padding-bottom: 24px;
+  min-width: 300px;
+  border-radius: 4px;
+}
+
+/* left animated "border" like hover element */
+.menuItemBorder {
+  position: absolute;
+  top: 2px;
+  left: 0px;
+  height: calc(100% - 4px);
+  width: 0;
+  background-color: var(--marketplaceColor);
+  transition: width var(--transitionStyleButton);
+}
+
+/* left static border for selected element */
+.menuItemBorderSelected {
+  position: absolute;
+  top: 2px;
+  left: 0px;
+  height: calc(100% - 7px);
+  width: 6px;
+  background-color: var(--matterColorDark);
+}
+
+.menuHeading {
+  /* @apply --marketplaceListingAttributeFontStyles; */
+  font-weight: var(--fontWeightSemiBold);
+  color: var(--matterColor);
+  margin-left: 30px;
+  margin-right: 30px;
+  margin-bottom: 24px;
+}
+
+.menuItem {
+  @apply --marketplaceListingAttributeFontStyles;
+  color: var(--matterColor);
+
+  /* Layout */
+  position: relative;
+  min-width: 300px;
+  margin: 0;
+  padding: 4px 30px;
+
+  /* Override button styles */
+  outline: none;
+  text-align: left;
+  border: none;
+
+  cursor: pointer;
+
+  &:focus,
+  &:hover {
+    color: var(--matterColorDark);
+  }
+
+  &:hover .menuItemBorder {
+    width: 6px;
+  }
+
+  &:disabled {
+    color: var(--matterColorAnti);
+    cursor: default;
+  }
+  &:disabled:hover .menuItemBorder {
+    width: 0;
+  }
+}
+
+.clearMenuItem {
+  @apply --marketplaceH4FontStyles;
+  font-weight: var(--fontWeightMedium);
+  color: var(--matterColorAnti);
+
+  /* Layout */
+  position: relative;
+  min-width: 300px;
+  margin: 0;
+  padding: 32px 30px 18px 30px;
+
+  /* Override button styles */
+  outline: none;
+  text-align: left;
+  border: none;
+
+  cursor: pointer;
+  transition: width var(--transitionStyleButton);
+
+  &:focus,
+  &:hover {
+    color: var(--matterColor);
+    transition: width var(--transitionStyleButton);
+  }
+}

--- a/src/components/SortBy/SortByPopup.css
+++ b/src/components/SortBy/SortByPopup.css
@@ -80,7 +80,6 @@
 }
 
 .menuHeading {
-  /* @apply --marketplaceListingAttributeFontStyles; */
   font-weight: var(--fontWeightSemiBold);
   color: var(--matterColor);
   margin-left: 30px;

--- a/src/components/SortBy/SortByPopup.js
+++ b/src/components/SortBy/SortByPopup.js
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import { string, func, arrayOf, shape, number } from 'prop-types';
+import classNames from 'classnames';
+
+import { Menu, MenuContent, MenuItem, MenuLabel } from '..';
+import css from './SortByPopup.css';
+
+const optionLabel = (options, key) => {
+  const option = options.find(o => o.key === key);
+  return option ? option.label : key;
+};
+
+const SortByIcon = () => {
+  return (
+    <span className={css.icon}>
+      <span className={css.iconUp}>▲</span>
+      <span className={css.iconDown}>▼</span>
+    </span>
+  );
+};
+
+class SortByPopup extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { isOpen: false };
+    this.onToggleActive = this.onToggleActive.bind(this);
+    this.selectOption = this.selectOption.bind(this);
+  }
+
+  onToggleActive(isOpen) {
+    this.setState({ isOpen: isOpen });
+  }
+
+  selectOption(urlParam, option) {
+    this.setState({ isOpen: false });
+    this.props.onSelect(urlParam, option);
+  }
+
+  render() {
+    const {
+      rootClassName,
+      className,
+      urlParam,
+      label,
+      options,
+      initialValue,
+      contentPlacementOffset,
+    } = this.props;
+
+    // resolve menu label text and class
+    const menuLabel = initialValue ? optionLabel(options, initialValue) : label;
+
+    const classes = classNames(rootClassName || css.root, className);
+
+    return (
+      <Menu
+        className={classes}
+        useArrow={false}
+        contentPlacementOffset={contentPlacementOffset}
+        onToggleActive={this.onToggleActive}
+        isOpen={this.state.isOpen}
+      >
+        <MenuLabel className={css.menuLabel}>
+          <SortByIcon />
+          {menuLabel}
+        </MenuLabel>
+        <MenuContent className={css.menuContent}>
+          <MenuItem key="sort-by">
+            <h4 className={css.menuHeading}>{label}</h4>
+          </MenuItem>
+          {options.map(option => {
+            // check if this option is selected
+            const selected = initialValue === option.key;
+            // menu item border class
+            const menuItemBorderClass = selected ? css.menuItemBorderSelected : css.menuItemBorder;
+
+            return (
+              <MenuItem key={option.key}>
+                <button
+                  className={css.menuItem}
+                  disabled={option.disabled}
+                  onClick={() => (selected ? null : this.selectOption(urlParam, option.key))}
+                >
+                  <span className={menuItemBorderClass} />
+                  {option.longLabel || option.label}
+                </button>
+              </MenuItem>
+            );
+          })}
+        </MenuContent>
+      </Menu>
+    );
+  }
+}
+
+SortByPopup.defaultProps = {
+  rootClassName: null,
+  className: null,
+  initialValue: null,
+  contentPlacementOffset: 0,
+};
+
+SortByPopup.propTypes = {
+  rootClassName: string,
+  className: string,
+  urlParam: string.isRequired,
+  label: string.isRequired,
+  onSelect: func.isRequired,
+  options: arrayOf(
+    shape({
+      key: string.isRequired,
+      label: string.isRequired,
+    })
+  ).isRequired,
+  initialValue: string,
+  contentPlacementOffset: number,
+};
+
+export default SortByPopup;

--- a/src/components/SortBy/SortByPopup.js
+++ b/src/components/SortBy/SortByPopup.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { string, func, arrayOf, shape, number } from 'prop-types';
 import classNames from 'classnames';
 
-import { Menu, MenuContent, MenuItem, MenuLabel } from '..';
+import { Menu, MenuContent, MenuItem, MenuLabel } from '../../components';
 import css from './SortByPopup.css';
 
 const optionLabel = (options, key) => {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -143,6 +143,7 @@ export { default as SearchMapPriceLabel } from './SearchMapPriceLabel/SearchMapP
 export { default as SearchResultsPanel } from './SearchResultsPanel/SearchResultsPanel';
 export { default as SelectMultipleFilter } from './SelectMultipleFilter/SelectMultipleFilter';
 export { default as SelectSingleFilter } from './SelectSingleFilter/SelectSingleFilter';
+export { default as SortBy } from './SortBy/SortBy';
 export { default as StripeConnectAccountStatusBox } from './StripeConnectAccountStatusBox/StripeConnectAccountStatusBox';
 export { default as StripePaymentAddress } from './StripePaymentAddress/StripePaymentAddress';
 export { default as UserCard } from './UserCard/UserCard';

--- a/src/containers/SearchPage/MainPanel.js
+++ b/src/containers/SearchPage/MainPanel.js
@@ -25,6 +25,7 @@ class MainPanel extends Component {
       className,
       rootClassName,
       urlQueryParams,
+      sort,
       listings,
       searchInProgress,
       searchListingsError,
@@ -78,6 +79,7 @@ class MainPanel extends Component {
         <SearchFilters
           className={css.searchFilters}
           urlQueryParams={urlQueryParams}
+          sort={sort}
           listingsAreLoaded={listingsAreLoaded}
           resultsCount={totalItems}
           searchInProgress={searchInProgress}
@@ -89,6 +91,7 @@ class MainPanel extends Component {
         <SearchFiltersMobile
           className={css.searchFiltersMobile}
           urlQueryParams={urlQueryParams}
+          sort={sort}
           listingsAreLoaded={listingsAreLoaded}
           resultsCount={totalItems}
           searchInProgress={searchInProgress}
@@ -107,6 +110,7 @@ class MainPanel extends Component {
           <div className={classNames(css.searchFiltersPanel)}>
             <SearchFiltersPanel
               urlQueryParams={urlQueryParams}
+              sort={sort}
               listingsAreLoaded={listingsAreLoaded}
               onClosePanel={() => this.setState({ isSearchFiltersPanelOpen: false })}
               filterParamNames={secondaryFilterParamNames}

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -158,7 +158,7 @@ export class SearchPageComponent extends Component {
       onActivateListing,
     } = this.props;
     // eslint-disable-next-line no-unused-vars
-    const { mapSearch, page, ...searchInURL } = parse(location.search, {
+    const { mapSearch, page, sort, ...searchInURL } = parse(location.search, {
       latlng: ['origin'],
       latlngBounds: ['bounds'],
     });
@@ -213,6 +213,7 @@ export class SearchPageComponent extends Component {
         <div className={css.container}>
           <MainPanel
             urlQueryParams={validQueryParams}
+            sort={sort}
             listings={listings}
             searchInProgress={searchInProgress}
             searchListingsError={searchListingsError}

--- a/src/marketplace-custom-config.js
+++ b/src/marketplace-custom-config.js
@@ -64,3 +64,24 @@ export const dateRangeFilterConfig = {
 export const keywordFilterConfig = {
   active: true,
 };
+
+const relevanceKey = 'relevance';
+
+export const sortConfig = {
+  // Enable/disable the sorting control in the SearchPage
+  active: true,
+
+  relevanceKey,
+
+  options: [
+    { key: 'createdAt', label: 'Newest' },
+    { key: '-createdAt', label: 'Oldest' },
+    { key: '-price', label: 'Lowest price' },
+    { key: 'price', label: 'Highest price' },
+
+    // The relevance is only used for keyword search, but the
+    // parameter isn't sent to the Marketplace API. The key is purely
+    // for handling the internal state of the sorting dropdown.
+    { key: relevanceKey, label: 'Relevance', longLabel: 'Relevance (Keyword search)' },
+  ],
+};

--- a/src/marketplace-custom-config.js
+++ b/src/marketplace-custom-config.js
@@ -65,13 +65,12 @@ export const keywordFilterConfig = {
   active: true,
 };
 
-const relevanceKey = 'relevance';
-
 export const sortConfig = {
   // Enable/disable the sorting control in the SearchPage
   active: true,
 
-  relevanceKey,
+  // Internal key for the relevance option, see notes below.
+  relevanceKey: 'relevance',
 
   options: [
     { key: 'createdAt', label: 'Newest' },
@@ -82,6 +81,6 @@ export const sortConfig = {
     // The relevance is only used for keyword search, but the
     // parameter isn't sent to the Marketplace API. The key is purely
     // for handling the internal state of the sorting dropdown.
-    { key: relevanceKey, label: 'Relevance', longLabel: 'Relevance (Keyword search)' },
+    { key: 'relevance', label: 'Relevance', longLabel: 'Relevance (Keyword search)' },
   ],
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -762,6 +762,7 @@
   "SignupForm.signUp": "Sign up",
   "SignupForm.termsAndConditionsAcceptText": "By signing up you accept the {termsLink}",
   "SignupForm.termsAndConditionsLinkText": "terms and conditions",
+  "SortBy.heading": "Sort by",
   "StripeBankAccountTokenInputField.accountNumber.inline": "account number",
   "StripeBankAccountTokenInputField.accountNumber.label": "Bank account number",
   "StripeBankAccountTokenInputField.accountNumber.placeholder": "Type in bank account number…",


### PR DESCRIPTION
This PR adds search results sorting to the SearchPage. Results can be sorted with these criteria:

- Newest
- Oldest
- Lowest price
- Highest price
- Relevance (Keyword search)

If there is a keyword filter, the relevance option is automatically selected and the other options are disabled. If there is no keyword, the relevance filter is disabled.

**NOTE:** The results count was moved to the left side of the sorting dropdown after these screenshots were taken.

## Default view

<img width="906" alt="Screenshot 2020-03-23 at 16 01 20" src="https://user-images.githubusercontent.com/53923/77324698-d0a35400-6d1f-11ea-90eb-7cfa9a6da42f.png">

## Mobile view

<img width="560" alt="Screenshot 2020-03-23 at 16 00 09" src="https://user-images.githubusercontent.com/53923/77324776-ef094f80-6d1f-11ea-82f7-bfd7a5794ea0.png">

## Mobile view with keyword filter

<img width="562" alt="Screenshot 2020-03-23 at 16 00 19" src="https://user-images.githubusercontent.com/53923/77324795-f7618a80-6d1f-11ea-926b-304985ce8c7d.png">

## Desktop view

<img width="1006" alt="Screenshot 2020-03-23 at 16 00 47" src="https://user-images.githubusercontent.com/53923/77324923-224bde80-6d20-11ea-91e4-eb9baafa397d.png">

## Desktop view with keyword filter

<img width="967" alt="Screenshot 2020-03-23 at 16 01 04" src="https://user-images.githubusercontent.com/53923/77324950-2aa41980-6d20-11ea-899f-7cea8a2a6ed2.png">

## Customization

The sorting is turned on by default. It can be disabled in the `marketplace-custom-config.js` with the `sortConfig.active` option.