### PR TITLE
Improve search filter UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] Improve the search page sorting and filters UI for different screen sizes [#1280](https://github.com/sharetribe/ftw-daily/pull/1280)
+
 ## [v4.4.0] 2020-03-25
 
 - [add] Search result sorting [#1277](https://github.com/sharetribe/ftw-daily/pull/1277)

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -27,6 +27,7 @@ const KEY_CODE_ESCAPE = 27;
 const CONTENT_PLACEMENT_OFFSET = 0;
 const CONTENT_TO_LEFT = 'left';
 const CONTENT_TO_RIGHT = 'right';
+const MAX_MOBILE_SCREEN_WIDTH = 768;
 
 const isControlledMenu = (isOpenProp, onToggleActiveProp) => {
   return isOpenProp !== null && onToggleActiveProp !== null;
@@ -103,12 +104,24 @@ class Menu extends Component {
 
   positionStyleForMenuContent(contentPosition) {
     if (this.menu && this.menuContent) {
+      const windowWidth = window.innerWidth;
+      const rect = this.menu.getBoundingClientRect();
+
       // Calculate wether we should show the menu to the left of the component or right
-      const distanceToRight = window.innerWidth - this.menu.getBoundingClientRect().right;
+      const distanceToRight = windowWidth - rect.right;
       const menuWidth = this.menu.offsetWidth;
       const contentWidthBiggerThanLabel = this.menuContent.offsetWidth - menuWidth;
       const usePositionLeftFromLabel = contentPosition === CONTENT_TO_LEFT;
       const contentPlacementOffset = this.props.contentPlacementOffset;
+
+      if (windowWidth <= MAX_MOBILE_SCREEN_WIDTH) {
+        // Take full screen width on mobile
+        return {
+          left: -1 * (rect.left - 24),
+          width: 'calc(100vw - 48px)',
+        };
+      }
+
       // Render menu content to the left according to the contentPosition
       // prop or if the content does not fit to the right. Otherwise render to
       // the right.

--- a/src/components/SearchFilters/SearchFilters.css
+++ b/src/components/SearchFilters/SearchFilters.css
@@ -18,7 +18,7 @@
   }
 }
 
-.resultOrganization {
+.searchOptions {
   display: flex;
   flex-direction: row;
   margin-bottom: 24px;

--- a/src/components/SearchFilters/SearchFilters.css
+++ b/src/components/SearchFilters/SearchFilters.css
@@ -4,10 +4,6 @@
   display: flex;
   flex-direction: column;
   background-color: var(--matterColorBright);
-
-  @media (--viewportLarge) {
-    flex-direction: row;
-  }
 }
 
 .longInfo {
@@ -22,13 +18,10 @@
   }
 }
 
-.organization {
+.resultOrganization {
   display: flex;
   flex-direction: row;
-
-  @media (--viewportLarge) {
-    margin-left: auto;
-  }
+  margin-bottom: 24px;
 }
 
 .searchResultSummary {
@@ -37,11 +30,7 @@
   margin-top: 10px;
   margin-bottom: 11px;
   margin-left: 0px;
-  margin-right: auto;
-
-  @media (--viewportLarge) {
-    margin-right: 8px;
-  }
+  margin-right: 8px;
 }
 
 .noSearchResults {

--- a/src/components/SearchFilters/SearchFilters.css
+++ b/src/components/SearchFilters/SearchFilters.css
@@ -4,12 +4,10 @@
   display: flex;
   flex-direction: column;
   background-color: var(--matterColorBright);
-}
 
-.filterWrapper {
-  display: flex;
-  justify-content: space-between;
-  position: relative;
+  @media (--viewportLarge) {
+    flex-direction: row;
+  }
 }
 
 .longInfo {
@@ -24,17 +22,26 @@
   }
 }
 
+.organization {
+  display: flex;
+  flex-direction: row;
+
+  @media (--viewportLarge) {
+    margin-left: auto;
+  }
+}
+
 .searchResultSummary {
   @apply --marketplaceH4FontStyles;
   line-height: 20px;
-  margin-top: 9px;
+  margin-top: 10px;
   margin-bottom: 11px;
-  margin-left: auto;
-  margin-right: 8px;
+  margin-left: 0px;
+  margin-right: auto;
 
-  /* parent uses flexbox: this defines minimum width for text "6 results" */
-  flex-basis: 55px;
-  flex-shrink: 0;
+  @media (--viewportLarge) {
+    margin-right: 8px;
+  }
 }
 
 .noSearchResults {

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -197,14 +197,14 @@ const SearchFiltersComponent = props => {
 
   return (
     <div className={classes}>
-      <div className={css.filterWrapper}>
-        <div className={css.filters}>
-          {priceFilterElement}
-          {dateRangeFilterElement}
-          {keywordFilterElement}
-          {toggleSearchFiltersPanelButton}
-        </div>
+      <div className={css.filters}>
+        {priceFilterElement}
+        {dateRangeFilterElement}
+        {keywordFilterElement}
+        {toggleSearchFiltersPanelButton}
+      </div>
 
+      <div className={css.organization}>
         {listingsAreLoaded && resultsCount > 0 ? (
           <div className={css.searchResultSummary}>
             <span className={css.resultsFound}>

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -197,15 +197,8 @@ const SearchFiltersComponent = props => {
 
   return (
     <div className={classes}>
-      <div className={css.filters}>
-        {priceFilterElement}
-        {dateRangeFilterElement}
-        {keywordFilterElement}
-        {toggleSearchFiltersPanelButton}
-      </div>
-
-      <div className={css.organization}>
-        {listingsAreLoaded && resultsCount > 0 ? (
+      <div className={css.resultOrganization}>
+        {listingsAreLoaded ? (
           <div className={css.searchResultSummary}>
             <span className={css.resultsFound}>
               <FormattedMessage id="SearchFilters.foundResults" values={{ count: resultsCount }} />
@@ -213,6 +206,13 @@ const SearchFiltersComponent = props => {
           </div>
         ) : null}
         {sortBy}
+      </div>
+
+      <div className={css.filters}>
+        {priceFilterElement}
+        {dateRangeFilterElement}
+        {keywordFilterElement}
+        {toggleSearchFiltersPanelButton}
       </div>
 
       {hasNoResult ? (

--- a/src/components/SearchFilters/SearchFilters.js
+++ b/src/components/SearchFilters/SearchFilters.js
@@ -197,7 +197,7 @@ const SearchFiltersComponent = props => {
 
   return (
     <div className={classes}>
-      <div className={css.resultOrganization}>
+      <div className={css.searchOptions}>
         {listingsAreLoaded ? (
           <div className={css.searchResultSummary}>
             <span className={css.resultsFound}>

--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.css
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.css
@@ -50,6 +50,9 @@
   @apply --marketplaceTinyFontStyles;
   font-weight: var(--fontWeightBold);
 
+  /* Avoid stretching button width. */
+  flex-basis: 0;
+
   height: 35px;
   min-height: 35px;
   padding: 0 18px;

--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.css
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.css
@@ -2,6 +2,7 @@
 
 .root {
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   background-color: var(--matterColorBright);
 
@@ -33,6 +34,9 @@
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceTinyFontStyles;
   font-weight: var(--fontWeightBold);
+
+  /* Avoid stretching button width. */
+  flex-basis: 0;
 
   height: 35px;
   min-height: 35px;

--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.css
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.css
@@ -53,6 +53,23 @@
   border-radius: 4px;
 }
 
+.sortBy {
+  margin-right: 9px;
+}
+
+.sortByMenuLabel {
+  @apply --marketplaceButtonStylesSecondary;
+  @apply --marketplaceTinyFontStyles;
+  font-weight: var(--fontWeightBold);
+
+  height: 35px;
+  min-height: 35px;
+  padding: 0 18px;
+  margin: 0;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
 .mapIcon {
   /* Font */
   @apply --marketplaceTinyFontStyles;

--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.js
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.js
@@ -315,7 +315,10 @@ class SearchFiltersMobileComponent extends Component {
 
     const sortBy = config.custom.sortConfig.active ? (
       <SortBy
+        rootClassName={css.sortBy}
+        menuLabelRootClassName={css.sortByMenuLabel}
         sort={sort}
+        showAsPopup
         isKeywordFilterActive={isKeywordFilterActive}
         onSelect={this.handleSortBy}
       />
@@ -332,6 +335,7 @@ class SearchFiltersMobileComponent extends Component {
           <Button rootClassName={filtersButtonClasses} onClick={this.openFilters}>
             <FormattedMessage id="SearchFilters.filtersButtonLabel" className={css.mapIconText} />
           </Button>
+          {sortBy}
           <div className={css.mapIcon} onClick={onMapIconClick}>
             <FormattedMessage id="SearchFilters.openMapView" className={css.mapIconText} />
           </div>
@@ -358,7 +362,6 @@ class SearchFiltersMobileComponent extends Component {
               {amenitiesFilterElement}
               {priceFilterElement}
               {dateRangeFilterElement}
-              {sortBy}
             </div>
           ) : null}
 

--- a/src/components/SortBy/SortByPopup.css
+++ b/src/components/SortBy/SortByPopup.css
@@ -45,7 +45,7 @@
 
 .menuContent {
   margin-top: 7px;
-  padding-top: 13px;
+  padding-top: 0;
   padding-bottom: 24px;
   min-width: 300px;
   border-radius: 4px;
@@ -75,6 +75,7 @@
 .menuHeading {
   font-weight: var(--fontWeightSemiBold);
   color: var(--matterColor);
+  margin-top: 24px;
   margin-left: 30px;
   margin-right: 30px;
 }

--- a/src/components/SortBy/SortByPopup.css
+++ b/src/components/SortBy/SortByPopup.css
@@ -5,21 +5,12 @@
 
 .icon {
   position: relative;
-  font-size: 10px;
-  margin-right: 15px;
-  color: var(--matterColor);
-}
+  bottom: 1px;
+  margin-right: 5px;
 
-.iconUp {
-  position: absolute;
-  left: 0;
-  top: -9px;
-}
-
-.iconDown {
-  position: absolute;
-  left: 0;
-  top: -0px;
+  @media (--viewportMedium) {
+    bottom: 2px;
+  }
 }
 
 .menuLabel {

--- a/src/components/SortBy/SortByPopup.js
+++ b/src/components/SortBy/SortByPopup.js
@@ -41,6 +41,7 @@ class SortByPopup extends Component {
     const {
       rootClassName,
       className,
+      menuLabelRootClassName,
       urlParam,
       label,
       options,
@@ -52,6 +53,7 @@ class SortByPopup extends Component {
     const menuLabel = initialValue ? optionLabel(options, initialValue) : label;
 
     const classes = classNames(rootClassName || css.root, className);
+    const menuLabelClasses = classNames(menuLabelRootClassName || css.menuLabel);
 
     return (
       <Menu
@@ -61,7 +63,7 @@ class SortByPopup extends Component {
         onToggleActive={this.onToggleActive}
         isOpen={this.state.isOpen}
       >
-        <MenuLabel className={css.menuLabel}>
+        <MenuLabel className={menuLabelClasses}>
           <SortByIcon />
           {menuLabel}
         </MenuLabel>
@@ -97,6 +99,7 @@ class SortByPopup extends Component {
 SortByPopup.defaultProps = {
   rootClassName: null,
   className: null,
+  menuLabelRootClassName: null,
   initialValue: null,
   contentPlacementOffset: 0,
 };
@@ -104,6 +107,7 @@ SortByPopup.defaultProps = {
 SortByPopup.propTypes = {
   rootClassName: string,
   className: string,
+  menuLabelRootClassName: string,
   urlParam: string.isRequired,
   label: string.isRequired,
   onSelect: func.isRequired,

--- a/src/components/SortBy/SortByPopup.js
+++ b/src/components/SortBy/SortByPopup.js
@@ -12,10 +12,18 @@ const optionLabel = (options, key) => {
 
 const SortByIcon = () => {
   return (
-    <span className={css.icon}>
-      <span className={css.iconUp}>▲</span>
-      <span className={css.iconDown}>▼</span>
-    </span>
+    <svg className={css.icon} width="10" height="16" xmlns="http://www.w3.org/2000/svg">
+      <g
+        stroke="#4a4a4a"
+        strokeWidth="1.5"
+        fill="none"
+        fillRule="evenodd"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M3.25 7.125v7.438M5 12.813l-1.75 1.75-1.75-1.75M6.75 8.875V1.438M5 3.188l1.75-1.75 1.75 1.75" />
+      </g>
+    </svg>
   );
 };
 


### PR DESCRIPTION
This PR improves the search page sorting controls for different screen sizes.

## Mobile

<img width="450" alt="Screenshot 2020-03-30 at 13 31 54" src="https://user-images.githubusercontent.com/53923/77903039-e4543a80-728a-11ea-94d0-ecbaf343bdd3.png">

## Desktop

<img width="1116" alt="Screenshot 2020-03-30 at 13 32 14" src="https://user-images.githubusercontent.com/53923/77903061-ecac7580-728a-11ea-83e8-bf19e6214e46.png">
