### PR TITLE
Remove string cleaning from state-saved values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,23 +14,28 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Allow white space on Japanese bank account info. Japan collects bank name and account owner
+  name in addition to routing numbers. [#1287](https://github.com/sharetribe/ftw-daily/pull/1287)
+
 ## [v4.4.2] 2020-04-09
 
-- [fix] Handle deleted reviews in ActivityFeed [#1283](https://github.com/sharetribe/ftw-daily/pull/1283)
+- [fix] Handle deleted reviews in ActivityFeed
+  [#1283](https://github.com/sharetribe/ftw-daily/pull/1283)
 
 [v4.4.2]: https://github.com/sharetribe/flex-template-web/compare/v4.4.1...v4.4.2
 
-
 ## [v4.4.1] 2020-03-30
 
-- [change] Improve the search page sorting and filters UI for different screen sizes [#1280](https://github.com/sharetribe/ftw-daily/pull/1280)
+- [change] Improve the search page sorting and filters UI for different screen sizes
+  [#1280](https://github.com/sharetribe/ftw-daily/pull/1280)
 
 [v4.4.1]: https://github.com/sharetribe/flex-template-web/compare/v4.4.0...v4.4.1
 
 ## [v4.4.0] 2020-03-25
 
 - [add] Search result sorting [#1277](https://github.com/sharetribe/ftw-daily/pull/1277)
-- [change] Move category and amenities search filters from primary filters to secondary filters. [#1275](https://github.com/sharetribe/ftw-daily/pull/1275)
+- [change] Move category and amenities search filters from primary filters to secondary filters.
+  [#1275](https://github.com/sharetribe/ftw-daily/pull/1275)
 
 [v4.4.0]: https://github.com/sharetribe/flex-template-web/compare/v4.3.0...v4.4.0
 

--- a/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.js
+++ b/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.js
@@ -9,7 +9,6 @@ import config from '../../config';
 
 import {
   BANK_ACCOUNT_INPUTS,
-  cleanedString,
   formatFieldMessage,
   requiredInputs,
   mapInputsToStripeAccountKeys,
@@ -150,19 +149,16 @@ class TokenInputFieldComponent extends Component {
         return result.token.id;
       })
       .then(token => {
+        // Check if value has changed during async call.
         const changedValues = inputsNeeded.filter(
-          inputType => values[inputType] !== cleanedString(this.state[inputType].value)
+          inputType => values[inputType] !== this.state[inputType].value
         );
         const valuesAreUnchanged = changedValues.length === 0;
 
         // Handle response only if the input values haven't changed
         if (this._isMounted && valuesAreUnchanged) {
           this.setState(prevState => {
-            const errorsClearedFromInputs = inputsNeeded.map(inputType => {
-              const input = prevState[inputType];
-              return { ...input, error: null };
-            });
-            return { ...errorsClearedFromInputs, stripeError: null };
+            return { stripeError: null };
           });
 
           onChange(token);
@@ -181,8 +177,8 @@ class TokenInputFieldComponent extends Component {
   }
 
   handleInputChange(e, inputType, country, intl) {
-    const rawValue = e.target.value;
-    const value = cleanedString(rawValue);
+    const value = e.target.value;
+
     let inputError = null;
 
     // Validate the changed routing number
@@ -194,7 +190,7 @@ class TokenInputFieldComponent extends Component {
 
     // Save changes to the state
     this.setState(prevState => {
-      const input = { ...prevState[inputType], value: rawValue, error: inputError };
+      const input = { ...prevState[inputType], value, error: inputError };
       return {
         [inputType]: input,
         stripeError: null,

--- a/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.util.js
+++ b/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.util.js
@@ -231,11 +231,11 @@ export const mapInputsToStripeAccountKeys = (country, values) => {
 
     case 'JP':
       return {
-        bank_name: cleanedString(values[BANK_NAME]),
-        branch_name: cleanedString(values[BRANCH_NAME]),
+        bank_name: values[BANK_NAME],
+        branch_name: values[BRANCH_NAME],
         routing_number: cleanedString(values[BANK_CODE]).concat(values[BRANCH_CODE]),
         account_number: cleanedString(values[ACCOUNT_NUMBER]),
-        account_holder_name: cleanedString(values[ACCOUNT_OWNER_NAME]),
+        account_holder_name: values[ACCOUNT_OWNER_NAME],
       };
 
     case 'MX':


### PR DESCRIPTION
This StripeBankAccountTokenInputField component is very old code (in a sense that there has been a lot of Stripe iteration and addition of new countries) - we should probably rewrite this component at some point. It's not even following our pretty old convention of naming Final Form field components as Field*.

This PR removes:
- String cleaning for state-saved values. 
  It is done only on code values (bank codes, routing numbers, account-number, etc.) sent to Stripe. 

  I wonder if that formatted code was originally used for some error printing (i.e. sent values). 

- Removed `errorsClearedFromInputs` state handling after the async call was made.
  This was dead code and just caused saving of duplicate info to state.  