### PR TITLE
New release v4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+## [v4.4.3] 2020-05-13
+
 - [fix] Allow white space on Japanese bank account info. Japan collects bank name and account owner
   name in addition to routing numbers. [#1287](https://github.com/sharetribe/ftw-daily/pull/1287)
 - [fix] wrongly named default props handleSubmit renamed to onSubmit
   [#1288](https://github.com/sharetribe/ftw-daily/pull/1288)
+
+[v4.4.3]: https://github.com/sharetribe/flex-template-web/compare/v4.4.2...v4.4.3
 
 ## [v4.4.2] 2020-04-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
- [fix] Allow white space on Japanese bank account info. Japan collects bank name and account owner
  name in addition to routing numbers. [#1287](https://github.com/sharetribe/ftw-daily/pull/1287)
- [fix] wrongly named default props handleSubmit renamed to onSubmit
  [#1288](https://github.com/sharetribe/ftw-daily/pull/1288)
