### PR TITLE
Fix missing node env from dev backend command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] `yarn run dev-backend` was expecting NODE_ENV.
+  [#1303](https://github.com/sharetribe/ftw-daily/pull/1303)
+
 ## [v5.0.0] 2020-06-04
 
 - [change] Streamlining filter setup. Everyone who customizes FTW-templates, needs to update filters

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "config": "node scripts/config.js",
     "config-check": "node scripts/config.js --check",
     "dev-frontend": "sharetribe-scripts start",
-    "dev-backend": "DEV_API_SERVER_PORT=3500 nodemon server/apiServer.js",
+    "dev-backend": "export NODE_ENV=development DEV_API_SERVER_PORT=3500&&nodemon server/apiServer.js",
     "dev": "yarn run config-check&&concurrently --kill-others \"yarn run dev-frontend\" \"yarn run dev-backend\"",
     "build": "sharetribe-scripts build",
     "format": "prettier --write '**/*.{js,css}'",


### PR DESCRIPTION
`yarn run dev-backend`, which was introduced in v4.5.0, was expecting NODE_ENV.