### PR TITLE
Opt-out flexible pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] Use privileged transitions for price calculation by default and
+  update the process alias.
+  [#1314](https://github.com/sharetribe/ftw-daily/pull/1314)
 - [add] Add client secret enquiry to 'yarn run config' script
   [#1313](https://github.com/sharetribe/ftw-daily/pull/1313)
 - [change] Add UI support for flexible pricing and privileged

--- a/ext/transaction-process/README.md
+++ b/ext/transaction-process/README.md
@@ -4,9 +4,8 @@ This is the transaction process that the Flex Template for Web is designed to wo
 The `process.edn` file describes the process flow while the `templates` folder contains notification
 messages that are used by the process.
 
-The process uses day-based booking and night-based pricing i.e. the quantity of booked units is
-defined by the number of nights in the booking. The process has preauthorization and it relies on
-the provider to accept booking requests.
-
-For different process descriptions for varying booking and pricing models, see the
-[Flex example processes repository](https://github.com/sharetribe/flex-example-processes)
+Bookings in the process are day-based. Pricing uses privileged transitions and
+the
+[privileged-set-line-items](https://www.sharetribe.com/docs/references/transaction-process-actions/#actionprivileged-set-line-items)
+action. The process has preauthorization and it relies on the provider to accept
+booking requests.

--- a/ext/transaction-process/process.edn
+++ b/ext/transaction-process/process.edn
@@ -9,22 +9,20 @@
    :actions
    [{:name :action/create-booking,
      :config {:observe-availability? true}}
-    {:name :action/calculate-tx-nightly-total-price}
-    {:name :action/calculate-tx-provider-commission,
-     :config {:commission 0.1M}}
+    {:name :action/privileged-set-line-items}
     {:name :action/stripe-create-payment-intent}],
-   :to :state/pending-payment}
+   :to :state/pending-payment
+   :privileged? true}
   {:name :transition/request-payment-after-enquiry,
    :actor :actor.role/customer,
    :actions
    [{:name :action/create-booking,
      :config {:observe-availability? true}}
-    {:name :action/calculate-tx-nightly-total-price}
-    {:name :action/calculate-tx-provider-commission,
-     :config {:commission 0.1M}}
+    {:name :action/privileged-set-line-items}
     {:name :action/stripe-create-payment-intent}],
    :from :state/enquiry,
-   :to :state/pending-payment}
+   :to :state/pending-payment
+   :privileged? true}
   {:name :transition/expire-payment,
    :at
    {:fn/plus

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ const sortSearchByDistance = false;
 //
 // In a way, 'processAlias' defines which transaction process (or processes)
 // this particular web application is able to handle.
-const bookingProcessAlias = 'preauth-nightly-booking/release-1';
+const bookingProcessAlias = 'flex-default-process/release-1';
 
 // The transaction line item code for the main unit type in bookings.
 //

--- a/src/util/transaction.js
+++ b/src/util/transaction.js
@@ -343,7 +343,7 @@ export const txRoleIsCustomer = userRole => userRole === TX_TRANSITION_ACTOR_CUS
 // should go through the local API endpoints, or if using JS SDK is
 // enough.
 export const isPrivileged = transition => {
-  return [
-    // list privileged transitions here
-  ].includes(transition);
+  return [TRANSITION_REQUEST_PAYMENT, TRANSITION_REQUEST_PAYMENT_AFTER_ENQUIRY].includes(
+    transition
+  );
 };


### PR DESCRIPTION
Based on #1310.

Make new Flex pricing the default pricing method.

- Add price calculation transitions to the list of privileged transitions
- Update transaction process definition
- Update default process alias