### PR TITLE
BookingUnitType config.js variable needed more comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Sync bookingUnitType variables and update comments. Client app's API (proxy) server needs to
+  know about unit type. [#1317](https://github.com/sharetribe/ftw-daily/pull/1317)
+
 ## [v6.0.0] 2020-06-25
 
 - [change] Use privileged transitions for price calculation by default and update the process alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,12 @@ way to update this template, but currently, we follow a pattern:
 
 ## [v6.0.0] 2020-06-25
 
-- [change] Use privileged transitions for price calculation by default and
-  update the process alias.
+- [change] Use privileged transitions for price calculation by default and update the process alias.
   [#1314](https://github.com/sharetribe/ftw-daily/pull/1314)
 - [add] Add client secret enquiry to 'yarn run config' script
   [#1313](https://github.com/sharetribe/ftw-daily/pull/1313)
-- [change] Add UI support for flexible pricing and privileged
-  transitions. Note that this requires updating the booking breakdown
-  estimation code that is now done in the backend.
+- [change] Add UI support for flexible pricing and privileged transitions. Note that this requires
+  updating the booking breakdown estimation code that is now done in the backend.
   [#1310](https://github.com/sharetribe/ftw-daily/pull/1310)
 - [add] Add local API endpoints for flexible pricing and privileged transitions
   [#1301](https://github.com/sharetribe/ftw-daily/pull/1301)

--- a/ext/transaction-process/README.md
+++ b/ext/transaction-process/README.md
@@ -4,8 +4,6 @@ This is the transaction process that the Flex Template for Web is designed to wo
 The `process.edn` file describes the process flow while the `templates` folder contains notification
 messages that are used by the process.
 
-Bookings in the process are day-based. Pricing uses privileged transitions and
-the
+Bookings in the process are day-based. Pricing uses privileged transitions and the
 [privileged-set-line-items](https://www.sharetribe.com/docs/references/transaction-process-actions/#actionprivileged-set-line-items)
-action. The process has preauthorization and it relies on the provider to accept
-booking requests.
+action. The process has preauthorization and it relies on the provider to accept booking requests.

--- a/server/api-util/lineItems.js
+++ b/server/api-util/lineItems.js
@@ -2,7 +2,9 @@ const { calculateQuantityFromDates, calculateTotalFromLineItems } = require('./l
 const { types } = require('sharetribe-flex-sdk');
 const { Money } = types;
 
-const unitType = 'line-item/night';
+// This bookingUnitType needs to be one of the following:
+// line-item/night, line-item/day or line-item/units
+const bookingUnitType = 'line-item/night';
 const PROVIDER_COMMISSION_PERCENTAGE = -10;
 
 /** Returns collection of lineItems (max 50)
@@ -40,9 +42,9 @@ exports.transactionLineItems = (listing, bookingData) => {
    * By default BookingBreakdown prints line items inside LineItemUnknownItemsMaybe if the lineItem code is not recognized. */
 
   const booking = {
-    code: 'line-item/night',
+    code: bookingUnitType,
     unitPrice,
-    quantity: calculateQuantityFromDates(startDate, endDate, unitType),
+    quantity: calculateQuantityFromDates(startDate, endDate, bookingUnitType),
     includeFor: ['customer', 'provider'],
   };
 

--- a/src/config.js
+++ b/src/config.js
@@ -38,8 +38,12 @@ const bookingProcessAlias = 'flex-default-process/release-1';
 //
 // Possible values: ['line-item/night', 'line-item/day', 'line-item/units';]
 //
-// Note: translations will use different translation keys for night, day or unit
-// depending on the value chosen.
+// Note 1: This 'bookingUnitType' variable affects only web app.
+//         If you are using privileged transitions (which is used by the default process),
+//         you also need to configure unit type in API server: server/api-util/lineItems.js
+//
+// Note 2: Translations will use different translation keys for night, day or unit
+//         depending on the value chosen.
 const bookingUnitType = 'line-item/night';
 
 // Should the application fetch available time slots (currently defined as

--- a/src/util/transaction.js
+++ b/src/util/transaction.js
@@ -108,7 +108,7 @@ const stateDescription = {
   // id is defined only to support Xstate format.
   // However if you have multiple transaction processes defined,
   // it is best to keep them in sync with transaction process aliases.
-  id: 'preauth-with-nightly-booking/release-1',
+  id: 'flex-default-process/release-1',
 
   // This 'initial' state is a starting point for new transaction
   initial: STATE_INITIAL,


### PR DESCRIPTION
This adds more comments about how to change booking unit type. 
I.e. the new API server/proxy creates it a bit more work for people who want to change the unit type from ´line-item/night´ to ´line-item/day´. 

We could also pass the bookingUnitType variable among bookingData to client app's server for flexible pricing calculations, but 
1) somehow adding more parameters that affect price calculations feels a bit wrong to me (customizers should think security concerns twice if they add more parameters)
2) "bookingData" has a bit different meaning in the web app's context (it contains any extra info from BookingDatesForm).