### PR TITLE
Fix: bounds were overwritten by state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] MainPanel: search filter bug. Address and bounds are handled outside of MainPanel, URL
+  params should be trusted instead of values stored to state.
+  [#1320](https://github.com/sharetribe/ftw-daily/pull/1320)
 - [fix] small typo. [#1319](https://github.com/sharetribe/ftw-daily/pull/1319)
 - [fix] Fix typo (which is copy-pasted in 4 files).
   [#1318](https://github.com/sharetribe/ftw-daily/pull/1318)

--- a/src/containers/SearchPage/MainPanel.js
+++ b/src/containers/SearchPage/MainPanel.js
@@ -117,8 +117,15 @@ class MainPanel extends Component {
 
     return updatedURLParams => {
       const updater = prevState => {
+        const { address, bounds } = urlQueryParams;
         const mergedQueryParams = { ...urlQueryParams, ...prevState.currentQueryParams };
-        return { currentQueryParams: { ...mergedQueryParams, ...updatedURLParams } };
+
+        // Address and bounds are handled outside of MainPanel.
+        // I.e. TopbarSearchForm && search by moving the map.
+        // We should always trust urlQueryParams with those.
+        return {
+          currentQueryParams: { ...mergedQueryParams, ...updatedURLParams, address, bounds },
+        };
       };
 
       const callback = () => {


### PR DESCRIPTION
Fix for bug report from FTW-hourly: https://github.com/sharetribe/ftw-hourly/pull/98

Address and bounds are handled outside of MainPanel.
(I.e. TopbarSearchForm && search by moving the map.)
We should always trust `urlQueryParams` with those.

How to reproduce: 
1. search location
2. edit filters
3. move the map (or search another location)
4. edit filters again.

URL gives initial values for filters, but in some rendering context user input is stored to the state before any "Apply" or "Reset" call is made. (Which is to say that URL might say that amenities "towel" is selected, but the user has altered that selection, but not yet applied it.) We store all the search/query parameters to state in MainPanel.js, but when one of the filters get updated we trusted location search params from the state instead of taking them directly from the URL params.