### PR TITLE
Improve StripeAccountLinkError error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] In `StripeConnectAccountForm` show error message from Stripe if there is one when
+  fetching account link. [#1346](https://github.com/sharetribe/ftw-daily/pull/1346)
+
 ## [v6.2.0] 2020-08-12
 
 This change set was originally released as a patch update 6.1.2 but after

--- a/src/forms/StripeConnectAccountForm/StripeConnectAccountForm.js
+++ b/src/forms/StripeConnectAccountForm/StripeConnectAccountForm.js
@@ -189,22 +189,24 @@ const UpdateStripeAccountFields = props => {
 
 const ErrorsMaybe = props => {
   const { stripeAccountError, stripeAccountLinkError } = props;
-  return isStripeError(stripeAccountError) ? (
-    <div className={css.error}>
-      <FormattedMessage
-        id="StripeConnectAccountForm.createStripeAccountFailedWithStripeError"
-        values={{ stripeMessage: stripeAccountError.apiErrors[0].meta.stripeMessage }}
-      />
-    </div>
+
+  const errorMessage = isStripeError(stripeAccountError) ? (
+    <FormattedMessage
+      id="StripeConnectAccountForm.createStripeAccountFailedWithStripeError"
+      values={{ stripeMessage: stripeAccountError.apiErrors[0].meta.stripeMessage }}
+    />
   ) : stripeAccountError ? (
-    <div className={css.error}>
-      <FormattedMessage id="StripeConnectAccountForm.createStripeAccountFailed" />
-    </div>
+    <FormattedMessage id="StripeConnectAccountForm.createStripeAccountFailed" />
+  ) : isStripeError(stripeAccountLinkError) ? (
+    <FormattedMessage
+      id="StripeConnectAccountForm.createStripeAccountLinkFailedWithStripeError"
+      values={{ stripeMessage: stripeAccountLinkError.apiErrors[0].meta.stripeMessage }}
+    />
   ) : stripeAccountLinkError ? (
-    <div className={css.error}>
-      <FormattedMessage id="StripeConnectAccountForm.createStripeAccountLinkFailed" />
-    </div>
+    <FormattedMessage id="StripeConnectAccountForm.createStripeAccountLinkFailed" />
   ) : null;
+
+  return errorMessage ? <div className={css.error}>{errorMessage}</div> : null;
 };
 
 const StripeConnectAccountFormComponent = props => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -919,6 +919,7 @@
   "StripeConnectAccountForm.createStripeAccountFailedWithStripeError": "Whoops, something went wrong. Stripe returned an error message: \"{stripeMessage}\"",
   "StripeConnectAccountForm.individualAccount": "I'm an individual",
   "StripeConnectAccountForm.createStripeAccountLinkFailed": "Whoops, something went wrong. Please contact your marketplace administrators.",
+    "StripeConnectAccountForm.createStripeAccountLinkFailedWithStripeError": "Whoops, something went wrong. Stripe returned an error message: \"{stripeMessage}\"",
   "StripeConnectAccountForm.loadingStripeAccountData": "Fetching payout details…",
   "StripeConnectAccountForm.stripeToSText": "By saving details, you agree to the {stripeConnectedAccountTermsLink}",
   "StripeConnectAccountForm.stripeConnectedAccountTermsLink": "Stripe Connected Account Agreement",


### PR DESCRIPTION
If there is StripeAccountLinkError with Stripe message, show the message from Stripe in UI same way as we show stripeAccountError messages. This should make it easier to e.g. notice if you haven't activated the Connect Onboarding yet. 

![Screenshot 2020-08-12 at 16 50 55](https://user-images.githubusercontent.com/9502221/90025090-510e2580-dcbe-11ea-8610-4c4abed5f204.png)
