### PR TITLE
Update path-to-regexp v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] Update path-to-regexp to v6.1.0
+  [#1348](https://github.com/sharetribe/ftw-daily/pull/1348)
 - [change] Update Helmet to v4.0.0. Show warning if environment variable REACT_APP_CSP is not set or
   if it's set to 'report' mode in production environmet. Set REACT_APP_CSP to 'report' mode by
   default in `.env-template` file. [#1347](https://github.com/sharetribe/ftw-daily/pull/1347)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "moment": "^2.22.2",
     "object.entries": "^1.1.2",
     "object.values": "^1.1.1",
-    "path-to-regexp": "^3.0.0",
+    "path-to-regexp": "^6.1.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.1",
     "raf": "^3.4.0",

--- a/src/util/routes.js
+++ b/src/util/routes.js
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 import { matchPath } from 'react-router-dom';
-import pathToRegexp from 'path-to-regexp';
+import { compile } from 'path-to-regexp';
 import { stringify } from './urlHelpers';
 
 const findRouteByName = (nameToFind, routes) => find(routes, route => route.name === nameToFind);
@@ -14,7 +14,7 @@ const toPathByRouteName = (nameToFind, routes) => {
   if (!route) {
     throw new Error(`Path "${nameToFind}" was not found.`);
   }
-  return pathToRegexp.compile(route.path);
+  return compile(route.path);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -8334,10 +8334,10 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.0.0.tgz#c981a218f3df543fa28696be2f88e0c58d2e012a"
-  integrity sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==
+path-to-regexp@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
 
 path-type@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
path-to-regexp (v3.0.0 -> v6.1.0) **doesn't contain default expor**t anymore.