### PR TITLE
Change font to poppins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] We decided to change the default font to Poppins.
+  [#1349](https://github.com/sharetribe/ftw-daily/pull/1349)
 - [change] Update path-to-regexp to v6.1.0
   [#1348](https://github.com/sharetribe/ftw-daily/pull/1348)
 - [change] Update Helmet to v4.0.0. Show warning if environment variable REACT_APP_CSP is not set or

--- a/public/500.html
+++ b/public/500.html
@@ -9,34 +9,31 @@
     <style>
 
      /**
-      * The fonts included are copyrighted by the vendor listed below.
+      * Poppins font is downloaded from Google Fonts
+      * but served from sharetribe.com assets.
       *
-      * Vendor:      Mostardesign
-      * License URL: https://www.fontspring.com/licenses/mostardesign/webfont
-      *
+      * https://fonts.google.com/specimen/Poppins
       */
+
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff') format('woff');
-          font-weight: 500; /* Medium */
-          font-style: normal;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Medium.ttf') format('truetype');
+        font-weight: 500; /* Medium */
+        font-style: normal;
       }
 
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff') format('woff');
-          font-weight: 600; /* SemiBold */
-          font-style: normal;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-SemiBold.ttf') format('truetype');
+        font-weight: 600; /* SemiBold */
+        font-style: normal;
       }
 
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-bold-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-bold-webfont.woff') format('woff');
-          font-weight: 700; /* Bold */
-          font-style: normal;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Bold.ttf') format('truetype');
+        font-weight: 700; /* Bold */
+        font-style: normal;
       }
 
       body {
@@ -125,7 +122,7 @@
       }
 
       .fontsLoaded body {
-        font-family: sofiapro, Helvetica, Arial, sans-serif;
+        font-family: poppins, Helvetica, Arial, sans-serif;
         opacity: 1;
       }
 
@@ -198,11 +195,11 @@
             return;
           }
 
-          var sofiaproMedium = new FontFace('sofiapro', 'url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff2") format("woff2"), url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff") format("woff")', { style: 'normal', weight: '500' });
-          var sofiaproSemibold = new FontFace('sofiapro', 'url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff2") format("woff2"), url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff") format("woff")', { style: 'normal', weight: '600' });
-          var sofiaproBold = new FontFace('sofiapro', 'url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-bold-webfont.woff2") format("woff2"), url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-bold-webfont.woff") format("woff")', { style: 'normal', weight: '700' });
+          var poppinsMedium = new FontFace('poppins', 'url("https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Medium.ttf") format("truetype")', { style: 'normal', weight: '500' });
+          var poppinsSemibold = new FontFace('poppins', 'url("https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-SemiBold.ttf") format("truetype")', { style: 'normal', weight: '600' });
+          var poppinsBold = new FontFace('poppins', 'url("https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Bold.ttf") format("truetype")', { style: 'normal', weight: '700' });
 
-          Promise.all([sofiaproMedium.load(), sofiaproSemibold.load(), sofiaproBold.load()])
+          Promise.all([poppinsMedium.load(), poppinsSemibold.load(), poppinsBold.load()])
             .then(function(values) {
               values.forEach(function(f) {
                 document.fonts.add(f);

--- a/public/index.html
+++ b/public/index.html
@@ -24,52 +24,43 @@
 
     <style>
      /**
-      * The fonts included are copyrighted by the vendor listed below.
-      *
-      * Vendor:      Mostardesign
-      * License URL: https://www.fontspring.com/licenses/mostardesign/webfont
-      *
+      * Poppins font is downloaded from Google Fonts but served from sharetribe.com / CDN
       */
 
       @font-face {
-        /* 'SofiaPro-Regular' */
-        font-family: 'sofiapro';
-        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-regular-webfont.woff2') format('woff2'),
-             url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-regular-webfont.woff') format('woff');
+        /* 'Poppins-Regular' */
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Regular.ttf') format('truetype');
         font-weight: 400; /* Regular */
         font-style: normal;
       }
 
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff') format('woff');
-          font-weight: 500; /* Medium */
-          font-style: normal;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Medium.ttf') format('truetype');
+        font-weight: 500; /* Medium */
+        font-style: normal;
       }
 
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-mediumit-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-mediumit-webfont.woff') format('woff');
-          font-weight: 500; /* Medium italics */
-          font-style: italic;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-MediumItalic.ttf') format('truetype');
+        font-weight: 500; /* Medium italics */
+        font-style: italic;
       }
 
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-semibold-webfont.woff') format('woff');
-          font-weight: 600; /* SemiBold */
-          font-style: normal;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-SemiBold.ttf') format('truetype');
+        font-weight: 600; /* SemiBold */
+        font-style: normal;
       }
 
       @font-face {
-          font-family: 'sofiapro';
-          src: url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-bold-webfont.woff2') format('woff2'),
-               url('https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-bold-webfont.woff') format('woff');
-          font-weight: 700; /* Bold */
-          font-style: normal;
+        font-family: 'poppins';
+        src: url('https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Bold.ttf') format('truetype');
+        font-weight: 700; /* Bold */
+        font-style: normal;
       }
 
     </style>
@@ -118,18 +109,18 @@
 
 
         // Fonts we use (Check font-face rules from <style> tag in <head> section)
-        var sofiaproRegular = new FontFaceObserver('sofiapro', { weight: 400 });
-        var sofiaproMedium = new FontFaceObserver('sofiapro', { weight: 500 });
-        var sofiaproSemibold = new FontFaceObserver('sofiapro', { weight: 600 });
-        var sofiaproBold = new FontFaceObserver('sofiapro', { weight: 700 });
+        var poppinsRegular = new FontFaceObserver('poppins', { weight: 400 });
+        var poppinsMedium = new FontFaceObserver('poppins', { weight: 500 });
+        var poppinsSemibold = new FontFaceObserver('poppins', { weight: 600 });
+        var poppinsBold = new FontFaceObserver('poppins', { weight: 700 });
 
         var fontLoadingTimeout = 5000;
 
         Promise.all([
-          sofiaproRegular.load(null, fontLoadingTimeout),
-          sofiaproMedium.load(null, fontLoadingTimeout),
-          sofiaproSemibold.load(null, fontLoadingTimeout),
-          sofiaproBold.load(null, fontLoadingTimeout)
+          poppinsRegular.load(null, fontLoadingTimeout),
+          poppinsMedium.load(null, fontLoadingTimeout),
+          poppinsSemibold.load(null, fontLoadingTimeout),
+          poppinsBold.load(null, fontLoadingTimeout)
         ])
           .then(function () {
             document.documentElement.classList.add("fontsLoaded");

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -16,7 +16,7 @@
 
   /* Base for all avatars */
   --Avatar_base: {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: 'poppins', Helvetica, Arial, sans-serif;
     border-radius: 50%;
 
     /* Position possible initials to the center of the component */
@@ -54,7 +54,6 @@
 .initials {
   font-size: 14px;
   font-weight: var(--fontWeightBold);
-  padding-bottom: 4px;
 }
 
 .avatarImage {
@@ -76,7 +75,6 @@
 .mediumAvatar .initials {
   font-size: 20px;
   font-weight: var(--fontWeightSemiBold);
-  padding-bottom: 5px;
 }
 
 /* Large Avatar */
@@ -92,7 +90,6 @@
 .largeAvatar .initials {
   font-size: 30px;
   font-weight: var(--fontWeightSemiBold);
-  padding-bottom: 6px;
 }
 
 .bannedUserIcon {

--- a/src/components/BookingBreakdown/BookingBreakdown.css
+++ b/src/components/BookingBreakdown/BookingBreakdown.css
@@ -112,7 +112,7 @@
 }
 
 .totalLabel {
-  font-weight: var(--fontWeightNormal);
+  @apply --marketplaceSmallFontStyles;
 }
 
 .totalPrice {

--- a/src/components/BookingPanel/BookingPanel.css
+++ b/src/components/BookingPanel/BookingPanel.css
@@ -71,8 +71,7 @@
 
   @media (--viewportLarge) {
     display: block;
-    margin-top: -2px;
-    margin-bottom: 33px;
+    margin-bottom: 30px;
   }
 }
 
@@ -81,7 +80,7 @@
   color: var(--matterColor);
 
   margin-top: 0;
-  margin-bottom: 9px;
+  margin-bottom: 2px;
 }
 
 .bookingHelp {

--- a/src/components/FieldDateInput/DateInput.css
+++ b/src/components/FieldDateInput/DateInput.css
@@ -79,7 +79,7 @@
 
   & :global(.DayPickerNavigation_button__horizontal) {
     padding: 6px 9px;
-    top: 19px;
+    top: 16px;
     position: absolute;
     cursor: pointer;
     display: inline;

--- a/src/components/FieldDateRangeController/DateRangeController.css
+++ b/src/components/FieldDateRangeController/DateRangeController.css
@@ -59,6 +59,10 @@
     &:last-of-type {
       right: 24px;
     }
+
+    @media (--viewportMedium) {
+      top: 18px;
+    }
   }
   & :global(.DayPickerNavigation_button) {
     color: var(--matterColor);

--- a/src/components/FieldDateRangeInput/DateRangeInput.css
+++ b/src/components/FieldDateRangeInput/DateRangeInput.css
@@ -45,7 +45,9 @@
   }
 
   & :global(.DateInput_input) {
+    @apply --marketplaceH4FontStyles;
     padding: 0;
+    margin: 0;
     border: 0;
     background: none;
   }
@@ -69,7 +71,7 @@
 
   & :global(.DayPickerNavigation_button__horizontal) {
     padding: 6px 9px;
-    top: 19px;
+    top: 16px;
     position: absolute;
     cursor: pointer;
     display: inline;

--- a/src/components/FilterPopup/FilterPopup.css
+++ b/src/components/FilterPopup/FilterPopup.css
@@ -9,7 +9,7 @@
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceSearchFilterLabelFontStyles;
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;
@@ -29,7 +29,7 @@
   @apply --marketplaceSearchFilterLabelFontStyles;
   font-weight: var(--fontWeightSemiBold);
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -126,12 +126,12 @@
 .organizationInfo {
 }
 
-.organizationDescription {
+.organizationDescription,
+.organizationCopyright {
   @apply --marketplaceTinyFontStyles;
 }
 
 .organizationCopyright {
-  @apply --marketplaceTinyFontStyles;
   margin-top: 32px;
 }
 
@@ -174,7 +174,7 @@
 
 .link {
   /* Font */
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   line-height: 20px;
   color: var(--matterColor);
   transition: var(--transitionStyleButton);
@@ -247,7 +247,6 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  margin-bottom: 12px;
 }
 
 .tosAndPrivacy {

--- a/src/components/KeywordFilter/KeywordFilter.css
+++ b/src/components/KeywordFilter/KeywordFilter.css
@@ -9,7 +9,7 @@
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceSearchFilterLabelFontStyles;
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;
@@ -29,7 +29,7 @@
   @apply --marketplaceSearchFilterLabelFontStyles;
   font-weight: var(--fontWeightSemiBold);
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/LayoutWrapperSideNav/LayoutWrapperSideNav.css
+++ b/src/components/LayoutWrapperSideNav/LayoutWrapperSideNav.css
@@ -14,7 +14,7 @@
   box-shadow: var(--boxShadow);
 
   @media (--viewportLarge) {
-    padding: 112px 0 82px 36px;
+    padding: 109px 0 82px 36px;
     flex-direction: column;
     justify-content: flex-start;
     border: none;
@@ -23,7 +23,7 @@
   }
 
   @media (--viewportLargeWithPaddings) {
-    padding: 112px 0 82px calc((100% - 1056px) / 2);
+    padding: 109px 0 82px calc((100% - 1056px) / 2);
   }
 }
 

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInput.css
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInput.css
@@ -113,6 +113,7 @@ bottom of the container.
     color: var(--matterColorLight);
     transition: var(--transitionStyleButton);
     margin: 0; /* Remove the double white space */
+    line-height: 24px;
 
     /* Assign enough vertical padding to make the element at least 44px high */
     padding: 9px var(--LocationAutocompleteInput_sidePadding);

--- a/src/components/PriceFilter/PriceFilterPopup.css
+++ b/src/components/PriceFilter/PriceFilterPopup.css
@@ -9,7 +9,7 @@
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceSearchFilterLabelFontStyles;
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;
@@ -29,7 +29,7 @@
   @apply --marketplaceSearchFilterLabelFontStyles;
   font-weight: var(--fontWeightSemiBold);
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/PrivacyPolicy/PrivacyPolicy.css
+++ b/src/components/PrivacyPolicy/PrivacyPolicy.css
@@ -6,10 +6,10 @@
   }
   & h2 {
     /* Adjust heading margins to work with the reduced body font size */
-    margin: 23px 0 19px 0;
+    margin: 29px 0 13px 0;
 
     @media (--viewportMedium) {
-      margin: 24px 0 24px 0;
+      margin: 32px 0 0 0;
     }
   }
 

--- a/src/components/PropertyGroup/PropertyGroup.css
+++ b/src/components/PropertyGroup/PropertyGroup.css
@@ -11,10 +11,10 @@
  */
 
   --PropertyGroup_lineHeight: 24px;
-  --PropertyGroup_lineThroughTop: calc(var(--PropertyGroup_lineHeight) - 7px);
-  --PropertyGroup_lineThroughBottom: calc(var(--PropertyGroup_lineHeight) - 6px);
-  --PropertyGroup_lineThroughTopMobile: calc(var(--PropertyGroup_lineHeight) - 9px);
-  --PropertyGroup_lineThroughBottomMobile: calc(var(--PropertyGroup_lineHeight) - 8px);
+  --PropertyGroup_lineThroughTop: 12px;
+  --PropertyGroup_lineThroughBottom: 13px;
+  --PropertyGroup_lineThroughTopMobile: 10px;
+  --PropertyGroup_lineThroughBottomMobile: 11px;
 }
 
 .root {

--- a/src/components/SavedCardDetails/SavedCardDetails.css
+++ b/src/components/SavedCardDetails/SavedCardDetails.css
@@ -110,7 +110,7 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: nowrap;
-  padding: 12px 24px 18px 16px;
+  padding: 12px 24px 10px 16px;
 }
 
 .menuLabelWrapperExpired {

--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.css
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.css
@@ -33,7 +33,7 @@
 .filtersButton {
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceTinyFontStyles;
-  font-weight: var(--fontWeightBold);
+  font-weight: var(--fontWeightMedium);
 
   /* Avoid stretching button width. */
   flex-basis: 0;
@@ -48,7 +48,7 @@
 .filtersButtonSelected {
   @apply --marketplaceButtonStyles;
   @apply --marketplaceTinyFontStyles;
-  font-weight: var(--fontWeightBold);
+  font-weight: var(--fontWeightMedium);
 
   /* Avoid stretching button width. */
   flex-basis: 0;
@@ -63,7 +63,7 @@
 .mapIcon {
   /* Font */
   @apply --marketplaceTinyFontStyles;
-  font-weight: var(--fontWeightBold);
+  font-weight: var(--fontWeightMedium);
 
   /* background map image */
   background-image: url(./images/map_icon216x105.png);

--- a/src/components/SearchFiltersPrimary/SearchFiltersPrimary.css
+++ b/src/components/SearchFiltersPrimary/SearchFiltersPrimary.css
@@ -79,7 +79,7 @@
   @apply --marketplaceSearchFilterLabelFontStyles;
 
   display: inline-block;
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;
@@ -100,7 +100,7 @@
   font-weight: var(--fontWeightSemiBold);
 
   display: inline-block;
-  padding: 9px 16px 10px 16px;
+  padding: 9px 16px 9px 16px;
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/SearchFiltersSecondary/SearchFiltersSecondary.css
+++ b/src/components/SearchFiltersSecondary/SearchFiltersSecondary.css
@@ -13,6 +13,7 @@
 
 .footer {
   display: flex;
+  margin-top: 8px;
 }
 
 .resetAllButton {

--- a/src/components/SearchMapInfoCard/SearchMapInfoCard.css
+++ b/src/components/SearchMapInfoCard/SearchMapInfoCard.css
@@ -58,7 +58,7 @@
 
 /* Overwrite Mapbox's specific font rules */
 .root .card {
-  font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+  font-family: 'poppins', Helvetica, Arial, sans-serif;
   font-weight: var(--fontWeightSemiBold);
 }
 
@@ -87,7 +87,7 @@
 
 .info {
   display: flex;
-  padding: 8px 16px;
+  padding: 11px 13px;
 }
 
 .price {

--- a/src/components/SectionHero/SectionHero.css
+++ b/src/components/SectionHero/SectionHero.css
@@ -83,7 +83,7 @@
 }
 
 .heroSubTitle {
-  @apply --marketplaceBodyFontStyles;
+  @apply --marketplaceH4FontStyles;
 
   color: var(--matterColorLight);
   margin: 0 0 32px 0;
@@ -93,7 +93,7 @@
 
   @media (--viewportMedium) {
     max-width: var(--SectionHero_desktopTitleMaxWidth);
-    margin: 0 0 63px 0;
+    margin: 0 0 47px 0;
   }
 }
 

--- a/src/components/SectionHowItWorks/SectionHowItWorks.css
+++ b/src/components/SectionHowItWorks/SectionHowItWorks.css
@@ -38,9 +38,9 @@
 }
 
 .createListingLink {
-  margin-top: 36px;
+  margin-top: 18px;
 
   @media (--viewportMedium) {
-    margin-top: 52px;
+    margin-top: 24px;
   }
 }

--- a/src/components/SectionLocations/SectionLocations.css
+++ b/src/components/SectionLocations/SectionLocations.css
@@ -4,21 +4,17 @@
   @apply --marketplaceH1FontStyles;
 
   margin-top: 0;
-  max-width: 735px;
-
-  @media (--viewportMedium) {
-    margin-bottom: 23px;
-  }
+  margin-bottom: 0;
 }
 
 .locations {
   display: flex;
   flex-direction: column;
-  margin-top: 32px;
+  margin-top: 0px;
 
   @media (--viewportMedium) {
     flex-direction: row;
-    margin-top: 57px;
+    margin-top: 33px;
   }
 }
 

--- a/src/components/SelectMultipleFilter/SelectMultipleFilter.css
+++ b/src/components/SelectMultipleFilter/SelectMultipleFilter.css
@@ -9,7 +9,7 @@
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceSearchFilterLabelFontStyles;
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;
@@ -29,7 +29,7 @@
   @apply --marketplaceSearchFilterLabelFontStyles;
   font-weight: var(--fontWeightSemiBold);
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/SelectSingleFilter/SelectSingleFilterPlain.css
+++ b/src/components/SelectSingleFilter/SelectSingleFilterPlain.css
@@ -99,7 +99,7 @@
 .option {
   @apply --marketplaceH4FontStyles;
   font-weight: var(--fontWeightMedium);
-  font-size: 18px;
+  font-size: 16px;
   color: var(--matterColor);
 
   /* Layout */

--- a/src/components/SelectSingleFilter/SelectSingleFilterPopup.css
+++ b/src/components/SelectSingleFilter/SelectSingleFilterPopup.css
@@ -8,8 +8,8 @@
   }
 }
 
-.menuLabel {
-  @apply --marketplaceButtonStylesSecondary;
+.menuLabel,
+.menuLabelSelected {
   @apply --marketplaceSearchFilterLabelFontStyles;
 
   padding: 9px 16px 10px 16px;
@@ -17,6 +17,10 @@
   height: auto;
   min-height: 0;
   border-radius: 4px;
+}
+
+.menuLabel {
+  @apply --marketplaceButtonStylesSecondary;
 
   &:focus {
     outline: none;
@@ -29,14 +33,8 @@
 
 .menuLabelSelected {
   @apply --marketplaceButtonStyles;
-  @apply --marketplaceSearchFilterLabelFontStyles;
   font-weight: var(--fontWeightSemiBold);
 
-  padding: 9px 16px 10px 16px;
-  width: auto;
-  height: auto;
-  min-height: 0;
-  border-radius: 4px;
   border: 1px solid var(--marketplaceColor);
 
   &:hover,

--- a/src/components/SelectSingleFilter/SelectSingleFilterPopup.css
+++ b/src/components/SelectSingleFilter/SelectSingleFilterPopup.css
@@ -12,7 +12,7 @@
 .menuLabelSelected {
   @apply --marketplaceSearchFilterLabelFontStyles;
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/SortBy/SortByPopup.css
+++ b/src/components/SortBy/SortByPopup.css
@@ -17,7 +17,7 @@
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceSearchFilterLabelFontStyles;
 
-  padding: 9px 16px 10px 16px;
+  padding: var(--marketplaceButtonSmallDesktopPadding);
   width: auto;
   height: auto;
   min-height: 0;

--- a/src/components/TermsOfService/TermsOfService.css
+++ b/src/components/TermsOfService/TermsOfService.css
@@ -6,10 +6,10 @@
   }
   & h2 {
     /* Adjust heading margins to work with the reduced body font size */
-    margin: 23px 0 19px 0;
+    margin: 29px 0 13px 0;
 
     @media (--viewportMedium) {
-      margin: 24px 0 24px 0;
+      margin: 32px 0 0 0;
     }
   }
 

--- a/src/components/TopbarDesktop/TopbarDesktop.css
+++ b/src/components/TopbarDesktop/TopbarDesktop.css
@@ -16,11 +16,11 @@
    */
   --TopbarDesktop_label: {
     display: inline-block;
-    margin: 24px 0;
+    margin: 28px 0;
     text-decoration: inherit;
 
     @media (--viewportMedium) {
-      margin: 24px 0;
+      margin: 28px 0;
     }
   }
 
@@ -116,7 +116,7 @@
 /* Create listing (CTA for providers) */
 .createListingLink {
   @apply --TopbarDesktop_linkHover;
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
 
   flex-shrink: 0;
   height: 100%;
@@ -142,7 +142,7 @@
 /* Inbox */
 .inboxLink {
   @apply --TopbarDesktop_linkHover;
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   height: 100%;
   padding: 0 12px 0 12px;
   margin-top: 0;
@@ -258,7 +258,7 @@
 
 .signup,
 .login {
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   @apply --TopbarDesktop_label;
 }
 
@@ -306,7 +306,7 @@
 .logoutButton {
   @apply --marketplaceLinkStyles;
   /* Font is specific to this component */
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   font-size: 14px;
 
   /* Dimensions */

--- a/src/components/UserCard/UserCard.css
+++ b/src/components/UserCard/UserCard.css
@@ -39,7 +39,7 @@
   @apply --marketplaceH4FontStyles;
 
   @media (--viewportMedium) {
-    margin: 18px 0 0 0;
+    margin: 0;
   }
 }
 
@@ -53,7 +53,6 @@
   display: none;
 
   @media (--viewportMedium) {
-    margin-top: 16px;
     display: block;
   }
 }

--- a/src/containers/AboutPage/AboutPage.css
+++ b/src/containers/AboutPage/AboutPage.css
@@ -52,6 +52,6 @@
 
 .subtitle {
   @apply --marketplaceH3FontStyles;
-  margin-top: 48px;
-  margin-bottom: 24px;
+  margin-top: 32px;
+  margin-bottom: 16px;
 }

--- a/src/containers/ContactDetailsPage/ContactDetailsPage.css
+++ b/src/containers/ContactDetailsPage/ContactDetailsPage.css
@@ -21,6 +21,6 @@
   margin-bottom: 19px;
 
   @media (--viewportMedium) {
-    margin-bottom: 48px;
+    margin-bottom: 36px;
   }
 }

--- a/src/containers/InboxPage/InboxPage.css
+++ b/src/containers/InboxPage/InboxPage.css
@@ -179,8 +179,8 @@
   }
 
   @media (--viewportLarge) {
-    margin-bottom: 24px;
-    padding-bottom: 15px;
+    margin-bottom: 16px;
+    padding-bottom: 7px;
   }
 }
 
@@ -211,7 +211,6 @@
   margin-right: 8px;
 
   @media (--viewportLarge) {
-    margin-top: 2px;
     margin-right: 15px;
   }
 }
@@ -251,7 +250,7 @@
   margin-bottom: 0;
 
   @media (--viewportMedium) {
-    margin-top: 3px;
+    margin-top: 0;
     margin-bottom: 0;
   }
 
@@ -274,18 +273,18 @@
 }
 
 .bookingInfoWrapper {
+  @apply --marketplaceTinyFontStyles;
+
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-
-  font-size: 14px;
   line-height: 14px;
   margin-top: 2px;
   padding-top: 2px;
 
   @media (--viewportMedium) {
     padding-top: 0px;
-    margin-top: 8px;
+    margin-top: 2px;
     line-height: 16px;
   }
 }
@@ -314,6 +313,9 @@
 }
 
 .lastTransitionedAt {
+  @apply --marketplaceTinyFontStyles;
+
+  margin-top: 4px;
   text-align: right;
   color: var(--matterColor);
 }

--- a/src/containers/ListingPage/ListingPage.css
+++ b/src/containers/ListingPage/ListingPage.css
@@ -156,7 +156,7 @@
   bottom: 19px;
   right: 24px;
   margin: 0;
-  padding: 6px 13px 8px 13px;
+  padding: 8px 13px 6px 13px;
 
   /* Colors */
   background-color: var(--matterColorLight);
@@ -234,7 +234,7 @@
 .bookingPanel {
   @media (--viewportLarge) {
     display: block;
-    margin-top: 95px;
+    margin-top: 79px;
     margin-left: 60px;
     border-left-style: solid;
     border-left-width: 1px;
@@ -289,7 +289,7 @@
 
   @media (--viewportMedium) {
     display: flex;
-    margin-bottom: 53px;
+    margin-bottom: 31px;
   }
 }
 .desktopPriceContainer {
@@ -308,12 +308,12 @@
 
 .desktopPriceValue {
   /* Font */
-  @apply --marketplaceH1FontStyles;
+  @apply --marketplaceModalTitleStyles;
   color: var(--marketplaceColor);
 
   @media (--viewportMedium) {
     margin-top: 0;
-    margin-bottom: 6px;
+    margin-bottom: 1px;
   }
 }
 
@@ -340,7 +340,7 @@
 
 .title {
   /* Font */
-  @apply --marketplaceH1FontStyles;
+  @apply --marketplaceModalTitleStyles;
   color: var(--matterColor);
 
   /* Layout */
@@ -349,13 +349,13 @@
   margin-bottom: 0;
   @media (--viewportMedium) {
     margin-top: 0;
-    margin-bottom: 5px;
+    margin-bottom: 2px;
   }
 }
 
 .author {
   width: 100%;
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   margin-top: 7px;
   margin-bottom: 0;
 
@@ -384,7 +384,7 @@
 
 .contactLink {
   @apply --marketplaceLinkStyles;
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   margin: 0;
 }
 
@@ -394,7 +394,7 @@
 
   @media (--viewportMedium) {
     padding: 0;
-    margin-bottom: 52px;
+    margin-bottom: 36px;
   }
 }
 
@@ -407,7 +407,7 @@
   margin-bottom: 13px;
   @media (--viewportMedium) {
     margin-top: 0;
-    margin-bottom: 20px;
+    margin-bottom: 12px;
   }
 }
 
@@ -430,7 +430,7 @@
   margin-bottom: 16px;
   @media (--viewportMedium) {
     margin-top: 0;
-    margin-bottom: 20px;
+    margin-bottom: 12px;
   }
 }
 

--- a/src/containers/ListingPage/SectionRulesMaybe.css
+++ b/src/containers/ListingPage/SectionRulesMaybe.css
@@ -19,7 +19,7 @@
   margin-bottom: 13px;
   @media (--viewportMedium) {
     margin-top: 0;
-    margin-bottom: 20px;
+    margin-bottom: 12px;
   }
 }
 

--- a/src/containers/ProfileSettingsPage/ProfileSettingsPage.css
+++ b/src/containers/ProfileSettingsPage/ProfileSettingsPage.css
@@ -36,7 +36,7 @@
   flex-shrink: 0;
 
   margin: 19px 0 0 auto;
-  padding: 9px 16px 8px 16px;
+  padding: 12px 16px 5px 16px;
 
   @media (--viewportMedium) {
     margin: 37px 0 0 auto;

--- a/src/containers/SearchPage/SearchPage.css
+++ b/src/containers/SearchPage/SearchPage.css
@@ -146,7 +146,7 @@
 .sortByMenuLabel {
   @apply --marketplaceButtonStylesSecondary;
   @apply --marketplaceTinyFontStyles;
-  font-weight: var(--fontWeightBold);
+  font-weight: var(--fontWeightMedium);
 
   height: 35px;
   min-height: 35px;

--- a/src/forms/EditListingAvailabilityForm/ManageAvailabilityCalendar.css
+++ b/src/forms/EditListingAvailabilityForm/ManageAvailabilityCalendar.css
@@ -248,6 +248,7 @@
 .monthElement {
   display: flex;
   position: relative;
+  top: 3px;
 }
 
 .monthString {

--- a/src/forms/PaymentMethodsForm/PaymentMethodsForm.js
+++ b/src/forms/PaymentMethodsForm/PaymentMethodsForm.js
@@ -52,17 +52,17 @@ const stripeErrorTranslation = (intl, stripeError) => {
 const stripeElementsOptions = {
   fonts: [
     {
-      family: 'sofiapro',
+      family: 'poppins',
       fontSmoothing: 'antialiased',
       src:
-        'local("sofiapro"), local("SofiaPro"), local("Sofia Pro"), url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff2") format("woff2")',
+        'local("poppins"), local("Poppins"), url("https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Medium.ttf") format("truetype")',
     },
   ],
 };
 
 const cardStyles = {
   base: {
-    fontFamily: '"sofiapro", Helvetica, Arial, sans-serif',
+    fontFamily: '"poppins", Helvetica, Arial, sans-serif',
     fontSize: '18px',
     fontSmoothing: 'antialiased',
     lineHeight: '24px',

--- a/src/forms/PriceFilterForm/PriceFilterForm.css
+++ b/src/forms/PriceFilterForm/PriceFilterForm.css
@@ -55,16 +55,17 @@
 }
 @media (--viewportMedium) {
   .contentWrapper {
-    padding-top: 7px;
-    padding-bottom: 7px;
+    padding-top: 0px;
+    padding-bottom: 8px;
     margin-top: 0px;
   }
 }
 
 .label {
-  @apply --marketplaceSearchFilterSublabelFontStyles;
-  padding: 8px 0 12px 0;
-  margin-right: 18px;
+  @apply --marketplaceH5FontStyles;
+  font-weight: var(--fontWeightSemiBold);
+  padding: 11px 0 13px 0;
+  margin: 0 18px 0 0;
 }
 @media (--viewportMedium) {
   .label {
@@ -74,6 +75,10 @@
 
 .inputsWrapper {
   display: flex;
+
+  @media (--viewportMedium) {
+    padding-bottom: 5px;
+  }
 }
 
 .minPrice {
@@ -89,6 +94,10 @@
     -webkit-appearance: none;
     margin: 0;
   }
+
+  @media (--viewportMedium) {
+    padding: 1px 0 4px 0;
+  }
 }
 .maxPrice {
   @apply --marketplaceSearchFilterSublabelFontStyles;
@@ -102,6 +111,10 @@
   &::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
+  }
+
+  @media (--viewportMedium) {
+    padding: 1px 0 4px 0;
   }
 }
 

--- a/src/forms/ProfileSettingsForm/ProfileSettingsForm.css
+++ b/src/forms/ProfileSettingsForm/ProfileSettingsForm.css
@@ -172,7 +172,7 @@
   /* Dimensions */
   width: 105px;
   height: 41px;
-  padding: 10px 10px 11px 35px;
+  padding: 11px 10px 7px 35px;
 
   /* Look and feel (buttonish) */
   background-color: var(--matterColorLight);
@@ -192,7 +192,7 @@
     margin-top: 0;
     margin-bottom: 0;
     transition: var(--transitionStyleButton);
-    padding: 7px 10px 11px 35px;
+    padding: 11px 10px 7px 35px;
   }
 
   &:hover {

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -63,17 +63,17 @@ const stripeErrorTranslation = (intl, stripeError) => {
 const stripeElementsOptions = {
   fonts: [
     {
-      family: 'sofiapro',
+      family: 'poppins',
       fontSmoothing: 'antialiased',
       src:
-        'local("sofiapro"), local("SofiaPro"), local("Sofia Pro"), url("https://assets-sharetribecom.sharetribe.com/webfonts/sofiapro/sofiapro-medium-webfont.woff2") format("woff2")',
+        'local("poppins"), local("Poppins"), url("https://assets-sharetribecom.sharetribe.com/webfonts/poppins/Poppins-Medium.ttf") format("truetype")',
     },
   ],
 };
 
 const cardStyles = {
   base: {
-    fontFamily: '"sofiapro", Helvetica, Arial, sans-serif',
+    fontFamily: '"poppins", Helvetica, Arial, sans-serif',
     fontSize: '18px',
     fontSmoothing: 'antialiased',
     lineHeight: '24px',

--- a/src/forms/TopbarSearchForm/TopbarSearchForm.css
+++ b/src/forms/TopbarSearchForm/TopbarSearchForm.css
@@ -48,7 +48,7 @@
 
   /* Layout */
   margin: 0 24px 0 0;
-  padding: 1px 13px 13px 13px;
+  padding: 4px 13px 10px 13px;
   height: var(--TopbarSearchForm_inputHeight);
   line-height: unset;
 
@@ -93,11 +93,6 @@
   text-overflow: ellipsis;
   overflow-x: hidden;
 
-  /* Safari bugfix: without this Safari will print placeholder to a wrong place */
-  &::-webkit-input-placeholder {
-    line-height: normal;
-  }
-
   &:hover,
   &:focus {
     border-bottom-color: var(--marketplaceColor);
@@ -113,7 +108,7 @@
   &::placeholder {
     text-overflow: ellipsis;
     overflow-x: hidden;
-    font-weight: var(--fontWeightRegular);
+    font-weight: var(--fontWeightMedium);
     transition: var(--transitionStyleButton);
   }
 

--- a/src/marketplace.css
+++ b/src/marketplace.css
@@ -160,11 +160,11 @@
   /* ================ Buttons ================ */
 
   --marketplaceButtonFontStyles: {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: 'poppins', Helvetica, Arial, sans-serif;
     font-weight: var(--fontWeightSemiBold);
-    font-size: 18px;
+    font-size: 16px;
     line-height: 24px;
-    letter-spacing: -0.3px;
+    letter-spacing: 0.2px;
 
     @media (--viewportMedium) {
       /* TODO: Make sure button text aligns with the baseline */
@@ -181,7 +181,11 @@
 
     /* Padding is only for <a> elements where button styles are applied,
 		buttons elements should have zero padding */
-    padding: 20px 0 0 0;
+    padding: 17px 0 17px 0;
+
+    @media (--viewportMedium) {
+      padding: 20px 0 20px 0;
+    }
 
     /* Borders */
     border: none;
@@ -289,7 +293,7 @@
     }
 
     @media (--viewportMedium) {
-      padding: 4px 0 10px 0;
+      padding: 4px 0 2px 0;
     }
   }
 
@@ -327,7 +331,7 @@
     }
 
     @media (--viewportMedium) {
-      padding: 4px 0 10px 0;
+      padding: 4px 0 2px 0;
     }
   }
 
@@ -456,7 +460,7 @@
   }
 
   --marketplaceModalHelperText {
-    @apply --marketplaceH5FontStyles;
+    @apply --marketplaceTinyFontStyles;
     color: var(--matterColorAnti);
     margin: 0;
 
@@ -466,7 +470,7 @@
   }
 
   --marketplaceModalHelperLink {
-    @apply --marketplaceH5FontStyles;
+    @apply --marketplaceTinyFontStyles;
     color: var(--matterColor);
     margin: 0;
 

--- a/src/marketplace.css
+++ b/src/marketplace.css
@@ -262,6 +262,8 @@
     }
   }
 
+  --marketplaceButtonSmallDesktopPadding: 9px 16px 9px 16px;
+
   /* ================ Inputs ================ */
 
   --marketplaceInputStyles: {

--- a/src/marketplaceFonts.css
+++ b/src/marketplaceFonts.css
@@ -11,6 +11,8 @@
     since browsers support CSS Properties already.
  */
 
+  --fontFamily: 'poppins', Helvetica, Arial, sans-serif;
+
   --fontWeightRegular: 400;
   --fontWeightMedium: 500;
   --fontWeightSemiBold: 600;
@@ -19,32 +21,32 @@
   /* ================ Default font ================ */
 
   --marketplaceDefaultFontStyles: {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightMedium);
-    font-size: 18px;
+    font-size: 14px;
     line-height: 24px;
     letter-spacing: -0.1px;
     /* No margins for default font */
 
     @media (--viewportMedium) {
-      font-size: 20px;
-      line-height: 24px;
+      font-size: 16px;
+      line-height: 32px;
     }
   }
 
   --marketplaceSmallFontStyles: {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightMedium);
-    font-size: 15px;
+    font-size: 14px;
     line-height: 24px;
   }
 
   /* ================ Body font ================ */
 
   --marketplaceBodyFontStyles: {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightMedium);
-    font-size: 18px;
+    font-size: 14px;
     line-height: 24px;
     letter-spacing: -0.1px;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
@@ -52,7 +54,7 @@
     margin-bottom: 12px;
 
     @media (--viewportMedium) {
-      font-size: 20px;
+      font-size: 16px;
       line-height: 32px;
       /* margin-top + n * line-height + margin-bottom => x * 8px */
       margin-top: 16px;
@@ -64,26 +66,20 @@
 
   --marketplaceHeroTitleFontStyles: {
     font-weight: var(--fontWeightBold);
-    font-size: 42px;
-    line-height: 42px;
-    letter-spacing: -1px;
+    font-size: 36px;
+    line-height: 36px;
+    letter-spacing: -0.7px;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
     margin-top: 25px;
-    margin-bottom: 20px;
+    margin-bottom: 14px;
 
     @media (--viewportMedium) {
-      font-size: 72px;
-      line-height: 72px;
+      font-size: 64px;
+      line-height: 64px;
       letter-spacing: -1.5px;
       /* margin-top + n * line-height + margin-bottom => x * 8px */
       margin-top: 25px;
-      margin-bottom: 31px;
-    }
-
-    @media (min-width: 1681px) {
-      font-size: 90px;
-      line-height: 96px;
-      letter-spacing: -2px;
+      margin-bottom: 23px;
     }
   }
 
@@ -95,12 +91,10 @@
     line-height: 36px;
     letter-spacing: -0.5px;
     margin: 0;
-    font-weight: var(--fontWeightBold);
 
     @media (--viewportMedium) {
       font-weight: var(--fontWeightSemiBold);
       line-height: 40px;
-      letter-spacing: -0.9px;
       margin: 0;
     }
   }
@@ -108,19 +102,19 @@
   /* ================ H1, H2, H3, H4, H5 & H6 ================ */
 
   --marketplaceH1FontStyles: {
-    font-weight: var(--fontWeightBold);
-    font-size: 30px;
-    line-height: 36px;
-    letter-spacing: -1px;
+    font-weight: var(--fontWeightSemiBold);
+    font-size: 24px;
+    line-height: 30px;
+    letter-spacing: -0.5px;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
     margin-top: 18px;
     margin-bottom: 18px;
 
     @media (--viewportMedium) {
-      font-size: 48px;
+      font-size: 40px;
       font-weight: var(--fontWeightSemiBold);
-      line-height: 56px;
-      letter-spacing: -2px;
+      line-height: 48px;
+      letter-spacing: -1px;
       /* margin-top + n * line-height + margin-bottom => x * 8px */
       margin-top: 24px;
       margin-bottom: 24px;
@@ -129,9 +123,8 @@
 
   --marketplaceH2FontStyles: {
     font-weight: var(--fontWeightSemiBold);
-    font-size: 24px;
-    line-height: 30px;
-    letter-spacing: -0.3px;
+    font-size: 21px;
+    line-height: 24px;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
     margin-top: 21px;
     margin-bottom: 17px;
@@ -146,9 +139,8 @@
 
   --marketplaceH3FontStyles: {
     font-weight: var(--fontWeightSemiBold);
-    font-size: 20px;
+    font-size: 18px;
     line-height: 24px;
-    letter-spacing: -0.2px;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
     margin-top: 16px;
     margin-bottom: 14px;
@@ -162,7 +154,7 @@
 
   --marketplaceH4FontStyles: {
     font-weight: var(--fontWeightMedium);
-    font-size: 16px;
+    font-size: 15px;
     line-height: 24px;
     letter-spacing: 0;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
@@ -178,7 +170,7 @@
   }
 
   --marketplaceH5FontStyles: {
-    font-weight: var(--fontWeightRegular);
+    font-weight: var(--fontWeightMedium);
     font-size: 14px;
     line-height: 18px;
     letter-spacing: 0;
@@ -187,7 +179,7 @@
     margin-bottom: 8px;
 
     @media (--viewportMedium) {
-      line-height: 24px;
+      line-height: 16px;
       /* margin-top + n * line-height + margin-bottom => x * 8px */
       margin-top: 10px;
       margin-bottom: 14px;
@@ -215,14 +207,14 @@
   /* ================ Other fonts ================ */
 
   --marketplaceTinyFontStyles: {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightRegular);
     font-size: 13px;
     line-height: 18px;
-    letter-spacing: -0.1px;
     /* margin-top + n * line-height + margin-bottom => x * 6px */
     margin-top: 9.5px;
     margin-bottom: 8.5px;
+    -webkit-font-smoothing: subpixel-antialiased;
 
     @media (--viewportMedium) {
       line-height: 16px;
@@ -233,63 +225,62 @@
   }
 
   --marketplaceMessageFontStyles {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightRegular);
     font-size: 16px;
     line-height: 24px;
   }
 
   --marketplaceMessageDateFontStyles {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightRegular);
-    font-size: 13px;
+    font-size: 12px;
     line-height: 18px;
-    letter-spacing: -0.1px;
 
     @media (--viewportMedium) {
       font-weight: var(--fontWeightMedium);
-      font-size: 13px;
+      font-size: 12px;
       line-height: 24px;
     }
   }
 
   --marketplaceTxTransitionFontStyles {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightMedium);
     font-size: 16px;
     line-height: 18px;
 
     @media (--viewportMedium) {
-      font-size: 20px;
-      line-height: 32px;
+      font-size: 16px;
+      line-height: 24px;
     }
   }
 
   --marketplaceSearchFilterLabelFontStyles {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightSemiBold);
     font-size: 13px;
     line-height: 18px;
 
     @media (--viewportMedium) {
       font-weight: var(--fontWeightMedium);
-      font-size: 16px;
+      font-size: 13px;
       line-height: 20px;
     }
   }
 
   --marketplaceSearchFilterSublabelFontStyles {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightMedium);
     font-size: 18px;
     line-height: 18px;
   }
 
   --marketplaceListingAttributeFontStyles {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: var(--fontFamily);
     font-weight: var(--fontWeightMedium);
-    font-size: 18px;
-    line-height: 32px;
+    font-size: 16px;
+    line-height: 24px;
   }
 
   /* ================ Tabbed navigation font styles ================ */
@@ -302,14 +293,14 @@
 
     @media (--viewportLarge) {
       font-weight: var(--fontWeightSemiBold);
-      font-size: 24px;
-      line-height: 32px;
+      font-size: 20px;
+      line-height: 24px;
     }
   }
 
   --marketplaceTabNavHorizontalFontStyles {
     font-weight: var(--fontWeightMedium);
-    font-size: 16px;
+    font-size: 14px;
     line-height: 24px;
     letter-spacing: 0;
   }

--- a/src/marketplaceIndex.css
+++ b/src/marketplaceIndex.css
@@ -50,6 +50,7 @@ textarea,
 select,
 li {
   @apply --marketplaceDefaultFontStyles;
+  line-height: 24px;
 }
 
 p,
@@ -73,7 +74,7 @@ ul {
 
 legend,
 label {
-  @apply --marketplaceH4FontStyles;
+  @apply --marketplaceH5FontStyles;
   font-weight: var(--fontWeightSemiBold);
   display: block;
   margin-top: 0;
@@ -118,9 +119,9 @@ textarea {
 
 :global(.fontsLoaded) {
   & body {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: 'poppins', Helvetica, Arial, sans-serif;
   }
   & button {
-    font-family: 'sofiapro', Helvetica, Arial, sans-serif;
+    font-family: 'poppins', Helvetica, Arial, sans-serif;
   }
 }


### PR DESCRIPTION
We are changing the font from Sofia Pro to Poppins.
This change is made because a private font's licencing scheme is a bit hard to work with.

Furthermore, the previous font was quite small - so, changing the font to some other font required quite many changes to components (as you can see from this PR).

Poppins is one of the Google Fonts, but with this change, we didn't move to Google Font's default loading setup. (At least, not yet.)  With directly controlling font files, we can better manage loading & rendering. Initial research through forums seems to suggest that this approach is faster. However, confirming that would require some real testing - so, at this point, we just followed the previous loading setup.

