### PR TITLE
New release: v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+## [v6.3.0] 2020-08-19
+
 - [change] We decided to change the default font to Poppins.
   [#1349](https://github.com/sharetribe/ftw-daily/pull/1349)
 - [change] Update path-to-regexp to v6.1.0
@@ -23,6 +25,8 @@ way to update this template, but currently, we follow a pattern:
   default in `.env-template` file. [#1347](https://github.com/sharetribe/ftw-daily/pull/1347)
 - [change] In `StripeConnectAccountForm` show error message from Stripe if there is one when
   fetching account link. [#1346](https://github.com/sharetribe/ftw-daily/pull/1346)
+
+[v6.2.0]: https://github.com/sharetribe/ftw-daily/compare/v6.2.0...v6.3.0
 
 ## [v6.2.0] 2020-08-12
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
**Note**: We have changed the default font to _Poppins_ and REACT_APP_CSP is giving warnings if it's not set.

- [change] We decided to change the default font to Poppins.
  [#1349](https://github.com/sharetribe/ftw-daily/pull/1349)
- [change] Update path-to-regexp to v6.1.0
  [#1348](https://github.com/sharetribe/ftw-daily/pull/1348)
- [change] Update Helmet to v4.0.0. Show warning if environment variable REACT_APP_CSP is not set or if it's set to 'report' mode in production environmet. Set REACT_APP_CSP to 'report' mode by default in `.env-template` file. 
  [#1347](https://github.com/sharetribe/ftw-daily/pull/1347)
- [change] In `StripeConnectAccountForm` show error message from Stripe if there is one when fetching account link.
  [#1346](https://github.com/sharetribe/ftw-daily/pull/1346)
