### PR TITLE
Fix: remove  douplicated page schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Remove duplicate page schema from body.
+  [#1355](https://github.com/sharetribe/ftw-daily/pull/1355)
+
 ## [v6.3.1] 2020-08-19
 
 - [fix] Fix popup-button in SelectSingleFilterPopup.css and adjust Footer with correct baselines.

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -43,6 +43,14 @@ class PageComponent extends Component {
     // handling both dragover and drop events.
     document.addEventListener('dragover', preventDefault);
     document.addEventListener('drop', preventDefault);
+
+    // Remove duplicated server-side rendered page schema.
+    // It's in <body> to improve initial rendering performance,
+    // but after web app is initialized, react-helmet-async operates with <head>
+    const pageSchema = document.getElementById('page-schema');
+    if (pageSchema) {
+      pageSchema.remove();
+    }
   }
 
   componentWillUnmount() {
@@ -197,7 +205,7 @@ class PageComponent extends Component {
           <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
           <meta httpEquiv="Content-Language" content={intl.locale} />
           {metaTags}
-          <script type="application/ld+json">
+          <script id="page-schema" type="application/ld+json">
             {schemaArrayJSONString.replace(/</g, '\\u003c')}
           </script>
         </Helmet>


### PR DESCRIPTION
This removes duplicate schema (LD+JSON) script element from the DOM. CSR removes #page-schema from DOM if one exists. We use "id" attribute to identify correct schema script (multiple schemas should be OK for search engines).

Note: Google schema debugger does notice that there was one script coming from SSR and CSR adds another on initial page load. 