### PR TITLE
Improve error handling by passing error details forward 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Improve error handling by passing error details forward instead of creating a new error that
+  hides the details when making API call to FTW server.
+  [#1361](https://github.com/sharetribe/ftw-daily/pull/1361)
 - [fix] Remove duplicate page schema from body.
   [#1355](https://github.com/sharetribe/ftw-daily/pull/1355)
 

--- a/server/api-util/sdk.js
+++ b/server/api-util/sdk.js
@@ -55,13 +55,16 @@ exports.deserialize = str => {
 exports.handleError = (res, error) => {
   console.error(error);
   if (error.status && error.statusText && error.data) {
+    const { status, statusText, data } = error;
+
     // JS SDK error
     res
       .status(error.status)
       .json({
-        status: error.status,
-        statusText: error.statusText,
-        data: error.data,
+        name: 'Local API request failed',
+        status,
+        statusText,
+        data,
       })
       .end();
   } else {

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -46,25 +46,25 @@ const post = (path, body) => {
     },
     body: serialize(body),
   };
-  return window
-    .fetch(url, options)
-    .then(res => {
-      const contentTypeHeader = res.headers.get('Content-Type');
-      const contentType = contentTypeHeader ? contentTypeHeader.split(';')[0] : null;
-      if (contentType === 'application/transit+json') {
-        return res.text().then(deserialize);
-      } else if (contentType === 'application/json') {
-        return res.json();
-      }
-      return res.text();
-    })
-    .then(res => {
-      if (res.status >= 400) {
-        const e = res;
+  return window.fetch(url, options).then(res => {
+    const contentTypeHeader = res.headers.get('Content-Type');
+    const contentType = contentTypeHeader ? contentTypeHeader.split(';')[0] : null;
+
+    if (res.status >= 400) {
+      return res.json().then(data => {
+        let e = new Error();
+        e = Object.assign(e, data);
+
         throw e;
-      }
-      return res;
-    });
+      });
+    }
+    if (contentType === 'application/transit+json') {
+      return res.text().then(deserialize);
+    } else if (contentType === 'application/json') {
+      return res.json();
+    }
+    return res.text();
+  });
 };
 
 // Fetch transaction line items from the local API endpoint.

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -49,14 +49,6 @@ const post = (path, body) => {
   return window
     .fetch(url, options)
     .then(res => {
-      if (res.status >= 400) {
-        const e = new Error('Local API request failed');
-        e.apiResponse = res;
-        throw e;
-      }
-      return res;
-    })
-    .then(res => {
       const contentTypeHeader = res.headers.get('Content-Type');
       const contentType = contentTypeHeader ? contentTypeHeader.split(';')[0] : null;
       if (contentType === 'application/transit+json') {
@@ -65,6 +57,13 @@ const post = (path, body) => {
         return res.json();
       }
       return res.text();
+    })
+    .then(res => {
+      if (res.status >= 400) {
+        const e = res;
+        throw e;
+      }
+      return res;
     });
 };
 


### PR DESCRIPTION
Improve error handling by passing error details forward instead of creating a new error that hides the details.

Using `e.apiResponse` directly didn't pass the data forward. Because the error details are saved to response.json and response.json() returns promise, we need to wait for that promise to resolve before we can access the data. 

Before:
![Screenshot 2020-09-18 at 14 17 13](https://user-images.githubusercontent.com/9502221/93593248-6d3b6b80-f9bc-11ea-8647-1a6da9b3c24b.png)



After:
![Screenshot 2020-09-18 at 14 16 38](https://user-images.githubusercontent.com/9502221/93592267-84795980-f9ba-11ea-85be-4ce9a6077138.png)


