### PR TITLE
Fix double rendering of Routes.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Routes component got double rendered due to Redux container HOC. Because navigation could
+  happen twice, loadData was also called twice.
+  [#1380](https://github.com/sharetribe/ftw-daily/pull/1380)
 - [fix] 401 return code when rendering on SSR.
   [#1379](https://github.com/sharetribe/ftw-daily/pull/1379)
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -71,6 +71,14 @@ const handleLocationChanged = (dispatch, location) => {
   dispatch(locationChanged(location, url));
 };
 
+/**
+ * RouteComponentRenderer handles loadData calls on client-side.
+ * It also checks authentication and redirects unauthenticated users
+ * away from routes that are for authenticated users only
+ * (aka "auth: true" is set in routeConfiguration.js)
+ *
+ * This component is a container: it needs to be connected to Redux.
+ */
 class RouteComponentRenderer extends Component {
   componentDidMount() {
     // Calling loadData on initial rendering (on client side).
@@ -104,9 +112,11 @@ class RouteComponentRenderer extends Component {
   }
 }
 
+RouteComponentRenderer.defaultProps = { staticContext: {} };
+
 RouteComponentRenderer.propTypes = {
-  isAuthenticated: bool.isRequired, // eslint-disable-line react/no-unused-prop-types
-  logoutInProgress: bool.isRequired, // eslint-disable-line react/no-unused-prop-types
+  isAuthenticated: bool.isRequired,
+  logoutInProgress: bool.isRequired,
   route: propTypes.route.isRequired,
   match: shape({
     params: object.isRequired,
@@ -115,21 +125,34 @@ RouteComponentRenderer.propTypes = {
   location: shape({
     search: string.isRequired,
   }).isRequired,
-  staticContext: object.isRequired,
-  // eslint-disable-next-line react/no-unused-prop-types
+  staticContext: object,
   dispatch: func.isRequired,
 };
 
+const mapStateToProps = state => {
+  const { isAuthenticated, logoutInProgress } = state.Auth;
+  return { isAuthenticated, logoutInProgress };
+};
+const RouteComponentContainer = compose(connect(mapStateToProps))(RouteComponentRenderer);
+
+/**
+ * Routes component creates React Router rendering setup.
+ * It needs routeConfiguration (named as "routes") through props.
+ * Using that configuration it creates navigation on top of page-level
+ * components. Essentially, it's something like:
+ * <Switch>
+ *   <Route render={pageA} />
+ *   <Route render={pageB} />
+ * </Switch>
+ */
 const Routes = (props, context) => {
-  const { isAuthenticated, logoutInProgress, staticContext, dispatch, routes } = props;
+  const { isAuthenticated, logoutInProgress, routes } = props;
 
   const toRouteComponent = route => {
     const renderProps = {
       isAuthenticated,
       logoutInProgress,
       route,
-      staticContext,
-      dispatch,
     };
 
     // By default, our routes are exact.
@@ -141,10 +164,11 @@ const Routes = (props, context) => {
         path={route.path}
         exact={isExact}
         render={matchProps => (
-          <RouteComponentRenderer
+          <RouteComponentContainer
             {...renderProps}
             match={matchProps.match}
             location={matchProps.location}
+            staticContext={matchProps.staticContext}
           />
         )}
       />
@@ -162,32 +186,8 @@ const Routes = (props, context) => {
   );
 };
 
-Routes.defaultProps = { staticContext: {} };
-
 Routes.propTypes = {
-  isAuthenticated: bool.isRequired,
-  logoutInProgress: bool.isRequired,
   routes: arrayOf(propTypes.route).isRequired,
-
-  // from withRouter
-  staticContext: object,
-
-  // from connect
-  dispatch: func.isRequired,
 };
 
-const mapStateToProps = state => {
-  const { isAuthenticated, logoutInProgress } = state.Auth;
-  return { isAuthenticated, logoutInProgress };
-};
-
-// Note: it is important that the withRouter HOC is **outside** the
-// connect HOC, otherwise React Router won't rerender any Route
-// components since connect implements a shouldComponentUpdate
-// lifecycle hook.
-//
-// See: https://github.com/ReactTraining/react-router/issues/4671
-export default compose(
-  withRouter,
-  connect(mapStateToProps)
-)(Routes);
+export default withRouter(Routes);


### PR DESCRIPTION
Redux container (connect HOC) caused double rendering for Routes component. 
Refactored the code to keep the React Router setup less error-prone and to avoid double navigation, which also manifested as calling the loadData function twice.

