### PR TITLE
In-app linking to the current page created unnecessary update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Call for the same page caused unnecessary rendering
+  [#1388](https://github.com/sharetribe/ftw-daily/pull/1388)
 - [fix] Fix Google Maps default centering if no bounds or center is given.
   [#1386](https://github.com/sharetribe/ftw-daily/pull/1386)
 - [add] Add timeout and other options for getCurrentLocation call.

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -86,12 +86,16 @@ class RouteComponentRenderer extends Component {
     handleLocationChanged(this.props.dispatch, this.props.location);
   }
 
-  componentDidUpdate() {
-    // Calling loadData after initial rendering (on client side).
-    // This makes it possible to use loadData as default client side data loading technique.
-    // However it is better to fetch data before location change to avoid "Loading data" state.
-    callLoadData(this.props);
-    handleLocationChanged(this.props.dispatch, this.props.location);
+  componentDidUpdate(prevProps) {
+    // Call for handleLocationChanged affects store/state
+    // and it generates an unnecessary update.
+    if (prevProps.location !== this.props.location) {
+      // Calling loadData after initial rendering (on client side).
+      // This makes it possible to use loadData as default client side data loading technique.
+      // However it is better to fetch data before location change to avoid "Loading data" state.
+      callLoadData(this.props);
+      handleLocationChanged(this.props.dispatch, this.props.location);
+    }
   }
 
   render() {


### PR DESCRIPTION
This *handleLocationChanged* call is also the root cause for the previous double rendering after full page refresh: [#1380](https://github.com/sharetribe/ftw-daily/pull/1380)
(Although, that PR was a good step to uncouple Router and Redux store - it fixed the full page load and improved the debuggability of this issue.)

Can be debugged by adding a breakpoint to *componentDidUpdate* and clicking *About* page link in the footer.