### PR TITLE
Metadata was not passed through sanitizeUser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Pass metadata through sanitizeUser function.
+  [#1391](https://github.com/sharetribe/ftw-daily/pull/1391)
 - [fix] Call for the same page caused unnecessary rendering
   [#1388](https://github.com/sharetribe/ftw-daily/pull/1388)
 - [fix] Fix Google Maps default centering if no bounds or center is given.

--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -34,11 +34,16 @@ const sanitizeText = str =>
 export const sanitizeUser = entity => {
   const { attributes, ...restEntity } = entity || {};
   const { profile, ...restAttributes } = attributes || {};
-  const { bio, displayName, abbreviatedName, publicData } = profile || {};
+  const { bio, displayName, abbreviatedName, publicData, metadata } = profile || {};
 
   const sanitizePublicData = publicData => {
     // TODO: If you add public data, you should probably sanitize it here.
     return publicData ? { publicData } : {};
+  };
+  const sanitizeMetadata = metadata => {
+    // TODO: If you add user-generated metadata through Integration API,
+    // you should probably sanitize it here.
+    return metadata ? { metadata } : {};
   };
 
   const profileMaybe = profile
@@ -48,6 +53,7 @@ export const sanitizeUser = entity => {
           displayName: sanitizeText(displayName),
           bio: sanitizeText(bio),
           ...sanitizePublicData(publicData),
+          ...sanitizeMetadata(metadata),
         },
       }
     : {};


### PR DESCRIPTION
User generated content can be sanitized in src/util/sanitize.js 
This PR fixes a bug related to that file: `sanitizeUser` function didn't pass metadata through.