### PR TITLE
Handle entity update with sparse attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] Handle entity update with sparse attributes.
+  [#1392](https://github.com/sharetribe/ftw-daily/pull/1392)
 - [change] Remove react-google-maps dependency. It has not been maintained for 3 years. From now on,
   we use Google Maps API directly. However, the default map provider is still Mapbox.
   [#1389](https://github.com/sharetribe/ftw-daily/pull/1389)

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -27,7 +27,10 @@ export const combinedResourceObjects = (oldRes, newRes) => {
     throw new Error('Cannot merge resource objects with different ids or types');
   }
   const attributes = newRes.attributes || oldRes.attributes;
-  const attrs = attributes ? { attributes: { ...attributes } } : null;
+  const attributesOld = oldRes.attributes || {};
+  const attributesNew = newRes.attributes || {};
+  // Allow (potentially) sparse attributes to update only relevant fields
+  const attrs = attributes ? { attributes: { ...attributesOld, ...attributesNew } } : null;
   const relationships = combinedRelationships(oldRes.relationships, newRes.relationships);
   const rels = relationships ? { relationships } : null;
   return { id, type, ...attrs, ...rels };


### PR DESCRIPTION
I think we have forgotten to think about this merging setup when sparse attributes were added to templates. 
However, I'm not entirely sure if we should make this update or not. Is there any reasonable customization concept that relies on "reduction" of marketplace data in the store?
(This PR was motivated by a recent question in Slack.)