### PR TITLE
New release v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+## [v7.1.0] 2020-12-15
+
 - [change] Handle entity update with sparse attributes.
   [#1392](https://github.com/sharetribe/ftw-daily/pull/1392)
 - [change] Remove react-google-maps dependency. It has not been maintained for 3 years. From now on,
@@ -29,6 +31,8 @@ way to update this template, but currently, we follow a pattern:
   [#1385](https://github.com/sharetribe/ftw-daily/pull/1385)
 - [fix] Fix FieldCheckbox validation on blur event on Firefox.
   [#1384](https://github.com/sharetribe/ftw-daily/pull/1384)
+
+  [v7.1.0]: https://github.com/sharetribe/ftw-daily/compare/v7.0.0...v7.1.0
 
 ## [v7.0.0] 2020-11-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## [v7.1.0] 2020-12-15

- [change] Handle entity update with sparse attributes.
  [#1392](https://github.com/sharetribe/ftw-daily/pull/1392)
- [change] Remove react-google-maps dependency. It has not been maintained for 3 years. From now on,
  we use Google Maps API directly. However, the default map provider is still Mapbox.
  [#1389](https://github.com/sharetribe/ftw-daily/pull/1389)
- [fix] Pass metadata through sanitizeUser function.
  [#1391](https://github.com/sharetribe/ftw-daily/pull/1391)
- [fix] Call for the same page caused unnecessary rendering
  [#1388](https://github.com/sharetribe/ftw-daily/pull/1388)
- [fix] Fix Google Maps default centering if no bounds or center is given.
  [#1386](https://github.com/sharetribe/ftw-daily/pull/1386)
- [add] Add timeout and other options for getCurrentLocation call.
  [#1385](https://github.com/sharetribe/ftw-daily/pull/1385)
- [fix] Fix FieldCheckbox validation on blur event on Firefox.
  [#1384](https://github.com/sharetribe/ftw-daily/pull/1384)

  [v7.1.0]: https://github.com/sharetribe/ftw-daily/compare/v7.0.0...v7.1.0
