### PR TITLE
Make sure verify API call succeeded before redirecting from EmailVerificationPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Make sure that the verify email API endpoint has been called successfully before redirecting
+  the user away from EmailVerificationPage.
+  [#1397](https://github.com/sharetribe/ftw-daily/pull/1397)
+
 ## [v7.2.0] 2020-12-16
 
 - [add] Add helper functions for setting up your own OIDC authentication and using FTW server as

--- a/src/containers/EmailVerificationPage/EmailVerificationPage.js
+++ b/src/containers/EmailVerificationPage/EmailVerificationPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { bool, func, shape, string } from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -51,6 +51,7 @@ export const EmailVerificationPageComponent = props => {
     intl,
     scrollingDisabled,
     submitVerification,
+    isVerified,
     emailVerificationInProgress,
     verificationError,
     location,
@@ -62,9 +63,12 @@ export const EmailVerificationPageComponent = props => {
   const initialValues = {
     verificationToken: parseVerificationToken(location ? location.search : null),
   };
-
   const user = ensureCurrentUser(currentUser);
-  if (user && user.attributes.emailVerified) {
+
+  // The first attempt to verify email is done when the page is loaded
+  // If the verify API call is successfull and the user has verified email
+  // We can redirect user forward from email verification page.
+  if (isVerified && user && user.attributes.emailVerified) {
     return <NamedRedirect name="LandingPage" />;
   }
 
@@ -104,12 +108,11 @@ EmailVerificationPageComponent.defaultProps = {
   verificationError: null,
 };
 
-const { bool, func, shape, string } = PropTypes;
-
 EmailVerificationPageComponent.propTypes = {
   currentUser: propTypes.currentUser,
   scrollingDisabled: bool.isRequired,
   submitVerification: func.isRequired,
+  isVerified: bool,
   emailVerificationInProgress: bool.isRequired,
   verificationError: propTypes.error,
 
@@ -124,8 +127,9 @@ EmailVerificationPageComponent.propTypes = {
 
 const mapStateToProps = state => {
   const { currentUser } = state.user;
-  const { verificationError, verificationInProgress } = state.EmailVerification;
+  const { isVerified, verificationError, verificationInProgress } = state.EmailVerification;
   return {
+    isVerified,
     verificationError,
     emailVerificationInProgress: verificationInProgress,
     currentUser,

--- a/src/forms/EmailVerificationForm/EmailVerificationForm.js
+++ b/src/forms/EmailVerificationForm/EmailVerificationForm.js
@@ -88,7 +88,7 @@ const EmailVerificationFormComponent = props => (
         </div>
       );
 
-      return emailVerified && !pendingEmail ? alreadyVerified : verifyEmail;
+      return emailVerified && !pendingEmail && !verificationError ? alreadyVerified : verifyEmail;
     }}
   />
 );


### PR DESCRIPTION
This PRs adds a check that the verify email API endpoint has been called successfully before redirecting the user away from EmailVerificationPage. 

Earlier, if another user was logged in that user had already verified their email the redirect happened even if the actual API call failed with 403 Forbidden. This caused some confusion if the user didn't notice they were logged in with the wrong account. 

Now we check the `isVerified` value which should be true only if the API call was successful. Checking just `verificationError ` was not enough because initially the `verificationError` is always null and the redirect happens before that value gets updated. Now if the user is logged in with the wrong account they will see the error that email verification failed. 



