### PR TITLE
Move OIDC .well-known/* routes outside apiRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Move well-known/\* endpoints related to OIDC proxy setup from `apiRouter` to new
+  `wellKnownRouter`so that they can be enabled outside the basic auth setup. It also makes it
+  simpler to set the identity provider url, because we can drop the `/api` part of the path. Also,
+  rename the `RSA_SECRET_KEY`to `RSA_PRIVATE_KEY` for consistency.
+  [#1399](https://github.com/sharetribe/ftw-daily/pull/1399)
 - [fix] Make sure that the verify email API endpoint has been called successfully before redirecting
   the user away from EmailVerificationPage.
   [#1397](https://github.com/sharetribe/ftw-daily/pull/1397)

--- a/server/api-util/idToken.js
+++ b/server/api-util/idToken.js
@@ -7,7 +7,7 @@ const PORT = parseInt(process.env.REACT_APP_DEV_API_SERVER_PORT, radix);
 const rootUrl = process.env.REACT_APP_CANONICAL_ROOT_URL;
 const useDevApiServer = process.env.NODE_ENV === 'development' && !!PORT;
 
-const issuerUrl = useDevApiServer ? `http://localhost:${PORT}/api` : `${rootUrl}/api`;
+const issuerUrl = useDevApiServer ? `http://localhost:${PORT}` : `${rootUrl}`;
 
 /**
  * Gets user information and creates the signed jwt for id token.

--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -21,8 +21,6 @@ const createUserWithIdp = require('./api/auth/createUserWithIdp');
 const { authenticateFacebook, authenticateFacebookCallback } = require('./api/auth/facebook');
 const { authenticateGoogle, authenticateGoogleCallback } = require('./api/auth/google');
 
-const { openIdConfiguration, jwksUri } = require('./api-util/idToken');
-
 const router = express.Router();
 
 // ================ API router middleware: ================ //
@@ -81,21 +79,5 @@ router.get('/auth/google', authenticateGoogle);
 // with Google. In this route a Passport.js custom callback is used for calling
 // loginWithIdp endpoint in Flex API to authenticate user to Flex
 router.get('/auth/google/callback', authenticateGoogleCallback);
-
-// These endpoints will be used if you FTW as OIDC proxy
-// https://www.sharetribe.com/docs/cookbook-social-logins-and-sso/setup-open-id-connect-proxy/
-// All identity providers should provide an OpenID Connect discovery document:
-// https://openid.net/specs/openid-connect-discovery-1_0.html
-// And in the discovery document we need to define jwks_uri attribute
-// which denotes the location of public signing keys
-
-const rsaSecretKey = process.env.RSA_SECRET_KEY;
-const rsaPublicKey = process.env.RSA_PUBLIC_KEY;
-const keyId = process.env.KEY_ID;
-
-if (rsaPublicKey && rsaSecretKey) {
-  router.get('/.well-known/openid-configuration', openIdConfiguration);
-  router.get('/.well-known/jwks.json', jwksUri([{ alg: 'RS256', rsaPublicKey, keyId }]));
-}
 
 module.exports = router;

--- a/server/apiServer.js
+++ b/server/apiServer.js
@@ -9,6 +9,7 @@ const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const apiRouter = require('./apiRouter');
+const wellKnownRouter = require('./wellKnownRouter');
 
 const radix = 10;
 const PORT = parseInt(process.env.REACT_APP_DEV_API_SERVER_PORT, radix);
@@ -23,6 +24,7 @@ app.use(
   })
 );
 app.use(cookieParser());
+app.use('/.well-known', wellKnownRouter);
 app.use('/api', apiRouter);
 
 app.listen(PORT, () => {

--- a/server/index.js
+++ b/server/index.js
@@ -33,6 +33,7 @@ const sitemap = require('express-sitemap');
 const passport = require('passport');
 const auth = require('./auth');
 const apiRouter = require('./apiRouter');
+const wellKnownRouter = require('./wellKnownRouter');
 const renderer = require('./renderer');
 const dataLoader = require('./dataLoader');
 const fs = require('fs');
@@ -131,9 +132,15 @@ app.use('/static', express.static(path.join(buildPath, 'static')));
 app.use('/robots.txt', express.static(path.join(buildPath, 'robots.txt')));
 app.use(cookieParser());
 
+// These .well-known/* endpoints will be enabled if you are using FTW as OIDC proxy
+// https://www.sharetribe.com/docs/cookbook-social-logins-and-sso/setup-open-id-connect-proxy/
+// We need to handle these endpoints separately so that they are accessible by Flex
+// even if you have enabled basic authentication e.g. in staging environment.
+app.use('/.well-known', wellKnownRouter);
+
 // Use basic authentication when not in dev mode. This is
-// intentionally after the static middleware to skip basic auth for
-// static resources.
+// intentionally after the static middleware and /.well-known
+// endpoints as those will bypass basic auth.
 if (!dev) {
   const USERNAME = process.env.BASIC_AUTH_USERNAME;
   const PASSWORD = process.env.BASIC_AUTH_PASSWORD;

--- a/server/wellKnownRouter.js
+++ b/server/wellKnownRouter.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { openIdConfiguration, jwksUri } = require('./api-util/idToken');
+
+const rsaPrivateKey = process.env.RSA_PRIVATE_KEY;
+const rsaPublicKey = process.env.RSA_PUBLIC_KEY;
+const keyId = process.env.KEY_ID;
+
+const router = express.Router();
+
+// These .well-known/* endpoints will be enabled if you are using FTW as OIDC proxy
+// https://www.sharetribe.com/docs/cookbook-social-logins-and-sso/setup-open-id-connect-proxy/
+if (rsaPublicKey && rsaPrivateKey) {
+  router.get('/openid-configuration', openIdConfiguration);
+  router.get('/jwks.json', jwksUri([{ alg: 'RS256', rsaPublicKey, keyId }]));
+}
+
+module.exports = router;


### PR DESCRIPTION
Move well-known/\* endpoints related to OIDC proxy setup from `apiRouter`to new `wellKnownRouter` so that they can be enabled outside the basic auth setup (e.g. ins staging environment). It also makes it simpler to set the identity provider URL, because we can drop the `/api` part of the path. 

We need to add the new `wellKnownRouter` to both `server/index.js` and `server/apiServer.js` because these routes are no longer handled in `apiRouter` but we want to be able to use them with both `yarn run dev` and `yarn run dev-server` commands. 

This PR also renames the environment variable `RSA_SECRET_KEY` to `RSA_PRIVATE_KEY` for consistency.