### PR TITLE
Specify required Node.js versions in package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   format:
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:12.19
     steps:
       - checkout
       - restore_cache:
@@ -25,7 +25,7 @@ jobs:
           command: yarn run format-ci
   test:
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:12.19
     steps:
       - checkout
       - restore_cache:
@@ -48,7 +48,7 @@ jobs:
           command: yarn run test-ci
   build:
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:12.19
     steps:
       - checkout
       - restore_cache:
@@ -71,7 +71,7 @@ jobs:
           command: yarn run build
   audit:
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:12.19
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [change] Specify required Node.js versions in package.json and update the node version used in
+  CircleCI. Currently, the required Node.js version comes from
+  [jose](https://github.com/panva/jose#runtime-support-matrix) package which is used with social
+  logins. [#1418](https://github.com/sharetribe/ftw-daily/pull/1418)
 - [fix] enforce upper case for currency and improve error message for it.
   [#1417](https://github.com/sharetribe/ftw-daily/pull/1417)
 - [add] Add `LoadableComponentErrorBoundary` for handling ChunkLoadErrors with error boundary.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
       "last 1 safari version"
     ]
   },
+
+   "engines": {
+    "node": "^12.19.0 || >= 14.15.0"
+  },
+
   "prettier": {
     "singleQuote": true,
     "trailingComma": "es5",


### PR DESCRIPTION
Specify required Node.js versions (^12.19.0 or ^14.15.0) in package.json. Currently, this restriction comes from jose library: https://github.com/panva/jose#runtime-support-matrix

<img width="560" alt="Screenshot 2021-03-04 at 14 03 57" src="https://user-images.githubusercontent.com/9502221/109961311-7b730f00-7cf2-11eb-8e4c-75ae5c9fd643.png">


