### PR TITLE
Release v8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+## [v8.1.1] 2021-04-20
+
 - [change] Update jose to v3.11.4 [#1433](https://github.com/sharetribe/ftw-daily/pull/1433)
 - [add] Update fr.json, es.json and partially de.json
   [#1431](https://github.com/sharetribe/ftw-daily/pull/1431)
@@ -22,6 +24,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] LoadableComponentErrorBoundary should be used in prod, not in dev-mode with
   hot-loading.[#1429](https://github.com/sharetribe/ftw-daily/pull/1429)
 - [fix] currency for Poland (PLN) [#1427](https://github.com/sharetribe/ftw-daily/pull/1427)
+
+  [v8.1.1]: https://github.com/sharetribe/ftw-daily/compare/v8.1.0...v8.1.1
 
 ## [v8.1.0] 2021-03-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
- [change] Update jose to v3.11.4 [#1433](https://github.com/sharetribe/ftw-daily/pull/1433)
- [add] Update fr.json, es.json and partially de.json
  [#1431](https://github.com/sharetribe/ftw-daily/pull/1431)
- [fix] currency conversion should not expect that env-variable is set.
  [#1425](https://github.com/sharetribe/ftw-daily/pull/1425)
- [fix] LoadableComponentErrorBoundary should be used in prod, not in dev-mode with
  hot-loading.[#1429](https://github.com/sharetribe/ftw-daily/pull/1429)
- [fix] currency for Poland (PLN) [#1427](https://github.com/sharetribe/ftw-daily/pull/1427)

Includes also dependabot updates:
- Bump y18n from 4.0.0 to 4.0.1
- Bump react-dev-utils from 11.0.2 to 11.0.4
- Bump ssri from 6.0.1 to 6.0.2
