### PR TITLE
Fix searchMode in new URL after map is changed

### DIFF
--- a/src/containers/SearchPage/SearchPage.helpers.js
+++ b/src/containers/SearchPage/SearchPage.helpers.js
@@ -33,10 +33,12 @@ export const validURLParamForExtendedData = (queryParamName, paramValueRaw, filt
     if (['SelectSingleFilter', 'SelectMultipleFilter'].includes(filterConfig.type)) {
       // Pick valid select options only
       const allowedValues = filterConfig.config.options.map(o => o.key);
+      const searchMode = filterConfig.config.searchMode;
       const valueArray = parseSelectFilterOptions(paramValue);
       const validValues = intersection(valueArray, allowedValues).join(',');
 
-      return validValues.length > 0 ? { [queryParamName]: validValues } : {};
+      return validValues.length > 0 ? { [queryParamName]: searchMode ? `${searchMode}:${validValues}` : validValues } 
+                                    : {};
     } else if (filterConfig.type === 'PriceFilter') {
       // Restrict price range to correct min & max
       const valueArray = paramValue ? paramValue.split(',') : [];


### PR DESCRIPTION
This PR is used to:
- Keep the existing applied searchMode in a newly created URL when the bounds of a map is changed on SearchPage