### PR TITLE
Remove thrown error on negative diff, when comparing server time with local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] minutesBetween: remove thrown an error on negative diff.
+  [#1444](https://github.com/sharetribe/ftw-daily/pull/1444)
 - [fix] TransactionPanel: fix typo [#1451](https://github.com/sharetribe/ftw-daily/pull/1451)
 - [fix] searchMode (has_all/has_any) disappeared, when search-by-moving-the-map was used.
   [#1443](https://github.com/sharetribe/ftw-daily/pull/1443)

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -115,19 +115,15 @@ export const daysBetween = (startDate, endDate) => {
 };
 
 /**
- * Calculate the number of minutes between the given dates
+ * Count the number of minutes between the given Date objects.
  *
  * @param {Date} startDate start of the time period
  * @param {Date} endDate end of the time period.
  *
- * @throws Will throw if the end date is before the start date
  * @returns {Number} number of minutes between the given Date objects
  */
 export const minutesBetween = (startDate, endDate) => {
   const minutes = moment(endDate).diff(startDate, 'minutes');
-  if (minutes < 0) {
-    throw new Error('End Date cannot be before start Date');
-  }
   return minutes;
 };
 

--- a/src/util/dates.test.js
+++ b/src/util/dates.test.js
@@ -82,11 +82,6 @@ describe('date utils', () => {
   });
 
   describe('minutesBetween()', () => {
-    it('should fail if end Date is before start Date', () => {
-      const start = new Date(2017, 0, 2);
-      const end = new Date(2017, 0, 1);
-      expect(() => minutesBetween(start, end)).toThrow('End Date cannot be before start Date');
-    });
     it('should handle equal start and end Dates', () => {
       const d = new Date(2017, 0, 1, 10, 35, 0);
       expect(minutesBetween(d, d)).toEqual(0);


### PR DESCRIPTION
If local time is not synchronized with some global time service, this error is thrown (because the fn is used on comparing server timestamp and local timestamp at checkout page).