### PR TITLE
Update sharetribe-scripts to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ way to update this template, but currently, we follow a pattern:
 
 ---
 
-## Upcoming version 2020-XX-XX
+## Upcoming version 2021-XX-XX
 
 - [fix] Remove unused dep-resolution: handlebars.
   [#1456](https://github.com/sharetribe/ftw-daily/pull/1456)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ way to update this template, but currently, we follow a pattern:
 - [fix] TransactionPanel: fix typo [#1451](https://github.com/sharetribe/ftw-daily/pull/1451)
 - [fix] searchMode (has_all/has_any) disappeared, when search-by-moving-the-map was used.
   [#1443](https://github.com/sharetribe/ftw-daily/pull/1443)
+- [change] Update sharetribe-scripts to version 5.0.1 which improves the
+  instructions that are shown after running yarn build command.
+  [#1458](https://github.com/sharetribe/ftw-daily/pull/1458)
 
 ## [v8.1.1] 2021-04-20
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "redux-thunk": "^2.3.0",
     "seedrandom": "^3.0.5",
     "sharetribe-flex-sdk": "1.13.0",
-    "sharetribe-scripts": "5.0.0",
+    "sharetribe-scripts": "5.0.1",
     "smoothscroll-polyfill": "^0.4.0",
     "source-map-support": "^0.5.9",
     "url": "^0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12375,10 +12375,10 @@ sharetribe-flex-sdk@1.13.0:
     lodash "^4.17.10"
     transit-js "^0.8.861"
 
-sharetribe-scripts@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/sharetribe-scripts/-/sharetribe-scripts-5.0.0.tgz#954f1eab7ed9209dc09ac9c44e39958c8e284a81"
-  integrity sha512-5/qe4jb5n0ilV+AL82wP/l+JD/wFXRTRYoKlpBIrXY++RQCBtx8psPPFR5+ZM133bzjonv2v+sYQUbX82lpykQ==
+sharetribe-scripts@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/sharetribe-scripts/-/sharetribe-scripts-5.0.1.tgz#16e0f6b3d63d1d183b9efece722f24753cebe8ee"
+  integrity sha512-iSRHUwhEacweN/Sfdp768GvBbgvQX03kslv5W3EaFTosCVNQORB/oHbB0svn051wYM+ZqaF/yGXraUNc+JwUrQ==
   dependencies:
     "@babel/core" "7.12.3"
     "@babel/plugin-transform-runtime" "7.12.1"


### PR DESCRIPTION
Update sharetribe-scripts to 5.0.1.

Version 5.0.1 improves the instructions that are shown after running `yarn build` command.