### PR TITLE
New release: v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+## [v8.2.0] 2021-08-06
+
 - [change] Update lodash version number in package.json resolutions section.
   [#1459](https://github.com/sharetribe/ftw-daily/pull/1459)
 - [change] Dependabot update: url-parse (v1.5.1)
@@ -40,6 +42,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] TransactionPanel: fix typo [#1451](https://github.com/sharetribe/ftw-daily/pull/1451)
 - [fix] searchMode (has_all/has_any) disappeared, when search-by-moving-the-map was used.
   [#1443](https://github.com/sharetribe/ftw-daily/pull/1443)
+
+  [v8.2.0]: https://github.com/sharetribe/ftw-daily/compare/v8.1.1...v8.2.0
 
 ## [v8.1.1] 2021-04-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## [v8.2.0] 2021-08-06

- [change] Update lodash version number in package.json resolutions section.
  [#1459](https://github.com/sharetribe/ftw-daily/pull/1459)
- [change] Dependabot update: url-parse (v1.5.1)
  [#1436](https://github.com/sharetribe/ftw-daily/pull/1436)
- [change] Dependabot update: lodash (v4.17.21)
  [#1437](https://github.com/sharetribe/ftw-daily/pull/1437)
- [change] Dependabot update: tar (v4.4.15)
  [#1457](https://github.com/sharetribe/ftw-daily/pull/1457)
- [change] Dependabot update: ws (v6.2.2) [#1446](https://github.com/sharetribe/ftw-daily/pull/1446)
- [change] Dependabot update: hosted-git-info (v2.8.9)
  [#1438](https://github.com/sharetribe/ftw-daily/pull/1438)
- [change] Dependabot update: trim-newlines (v3.0.1)
  [#1449](https://github.com/sharetribe/ftw-daily/pull/1449)
- [change] Update sharetribe-scripts to version 5.0.1 which improves the instructions that are shown
  after running yarn build command. [#1458](https://github.com/sharetribe/ftw-daily/pull/1458)
- [fix] Remove unused dep-resolution: handlebars.
  [#1456](https://github.com/sharetribe/ftw-daily/pull/1456)
- [fix] PriceFilterPopup: filter popup is not closing when clicking outside on Safari.
  [#1455](https://github.com/sharetribe/ftw-daily/pull/1455)
- [fix] Add missing helper: isNumber. Used when Number.MAX_SAFE_INTEGER is reached.
  [#1453](https://github.com/sharetribe/ftw-daily/pull/1453)
- [fix] minutesBetween: remove thrown an error on negative diff.
  [#1444](https://github.com/sharetribe/ftw-daily/pull/1444)
- [fix] TransactionPanel: fix typo [#1451](https://github.com/sharetribe/ftw-daily/pull/1451)
- [fix] searchMode (has_all/has_any) disappeared, when search-by-moving-the-map was used.
  [#1443](https://github.com/sharetribe/ftw-daily/pull/1443)

  [v8.2.0]: https://github.com/sharetribe/ftw-daily/compare/v8.1.1...v8.2.0
