### PR TITLE
Ghostery and other adblockers might block ga script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+- [fix] Adblockers might block Google analytics (window.ga) and cause an error.
+  [#1462](https://github.com/sharetribe/ftw-daily/pull/1462)
+
 ## [v8.2.0] 2021-08-06
 
 - [change] Update lodash version number in package.json resolutions section.

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,14 @@ const setupAnalyticsHandlers = () => {
 
   // Add Google Analytics handler if tracker ID is found
   if (process.env.REACT_APP_GOOGLE_ANALYTICS_ID) {
-    handlers.push(new GoogleAnalyticsHandler(window.ga));
+    if (window?.ga) {
+      handlers.push(new GoogleAnalyticsHandler(window.ga));
+    } else {
+      // Some adblockers (e.g. Ghostery) might block the Google Analytics integration.
+      console.warn(
+        'Google Analytics (window.ga) is not available. It might be that your adblocker is blocking it.'
+      );
+    }
   }
 
   return handlers;


### PR DESCRIPTION
Adblockers might block Google analytics (window.ga) and cause an error.