### PR TITLE
Stripe Elements couldn't calculate its wow-effects because font-size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+- [fix] Font-size for Poppins font was too big for Stripe Elements on small screens.
+  [#1465](https://github.com/sharetribe/ftw-daily/pull/1465)
 - [change] Updates to some of the libraries. React Intl had a breaking change v3 -> v5.
   [#464](https://github.com/sharetribe/ftw-daily/pull/1464)
 - [fix] Adblockers might block Google analytics (window.ga) and cause an error.

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -71,10 +71,14 @@ const stripeElementsOptions = {
   ],
 };
 
+// card (being a Stripe Elements component), can have own styling passed to it.
+// However, its internal width-calculation seems to break if font-size is too big
+// compared to component's own width.
+const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 const cardStyles = {
   base: {
     fontFamily: '"poppins", Helvetica, Arial, sans-serif',
-    fontSize: '18px',
+    fontSize: isMobile ? '14px' : '18px',
     fontSmoothing: 'antialiased',
     lineHeight: '24px',
     letterSpacing: '-0.1px',
@@ -236,10 +240,10 @@ class StripePaymentForm extends Component {
       // EventListener is the only way to simulate breakpoints with Stripe.
       window.addEventListener('resize', () => {
         if (this.card) {
-          if (window.innerWidth < 1024) {
-            this.card.update({ style: { base: { fontSize: '18px', lineHeight: '24px' } } });
+          if (window.innerWidth < 768) {
+            this.card.update({ style: { base: { fontSize: '14px', lineHeight: '24px' } } });
           } else {
-            this.card.update({ style: { base: { fontSize: '20px', lineHeight: '32px' } } });
+            this.card.update({ style: { base: { fontSize: '18px', lineHeight: '24px' } } });
           }
         }
       });


### PR DESCRIPTION
On small screens, payment card input (rendered by stripe.js) was aligning card number and expiration date on top of each other. Something inside the Stripe Elements seems to calculate widths wrongly if card number is too wide compared to component's overall width.

Fixed by reducing font-size.

Note: originally this code was made for other font - so, the font-size etc. wasn't really tuned for Poppins.