### PR TITLE
Reduce font-size even more for Stripe Elements component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2021-XX-XX
+
+- [fix] Font-size was too big for Stripe Elements on small screens. 14px > 13px.
+  [#1470](https://github.com/sharetribe/ftw-daily/pull/1470)
 - [fix] Remove unnecessary language import: fr.json
   [#1469](https://github.com/sharetribe/ftw-daily/pull/1469)
 - [fix] Font-size for Poppins font was too big for Stripe Elements on small screens.

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -78,7 +78,7 @@ const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 const cardStyles = {
   base: {
     fontFamily: '"poppins", Helvetica, Arial, sans-serif',
-    fontSize: isMobile ? '14px' : '18px',
+    fontSize: isMobile ? '13px' : '18px',
     fontSmoothing: 'antialiased',
     lineHeight: '24px',
     letterSpacing: '-0.1px',
@@ -241,7 +241,7 @@ class StripePaymentForm extends Component {
       window.addEventListener('resize', () => {
         if (this.card) {
           if (window.innerWidth < 768) {
-            this.card.update({ style: { base: { fontSize: '14px', lineHeight: '24px' } } });
+            this.card.update({ style: { base: { fontSize: '13px', lineHeight: '24px' } } });
           } else {
             this.card.update({ style: { base: { fontSize: '18px', lineHeight: '24px' } } });
           }


### PR DESCRIPTION
Even 14px was too big for certain languages. This reduces it to 13px.