### PR TITLE
Increase input font size to avoid zoom on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+- [change] Increase input font size on mobile to avoid Mobile Safari zooming in when focusing on
+  inputs. [#1473](https://github.com/sharetribe/ftw-daily/pull/1473)
 - [change] Update browserlist data to match modern browsers.
   [#1468](https://github.com/sharetribe/ftw-daily/pull/1468)
 - [fix] Font-size was too big for Stripe Elements on small screens on PaymentMethodsForm.

--- a/src/styles/marketplaceDefaults.css
+++ b/src/styles/marketplaceDefaults.css
@@ -206,12 +206,24 @@ h6 {
   @apply --marketplaceH6FontStyles;
 }
 
-input,
+input {
+  font-family: var(--fontFamily);
+  font-weight: var(--fontWeightMedium);
+  font-size: 16px;
+  line-height: 24px;
+  letter-spacing: -0.1px;
+  /* No margins for default font */
+
+  @media (--viewportMedium) {
+    font-size: 16px;
+    line-height: 32px;
+  }
+}
+
 textarea,
 select,
 li {
   @apply --marketplaceDefaultFontStyles;
-  line-height: 24px;
 }
 
 p,


### PR DESCRIPTION
If the input font size is smaller than 16px, iOS zooms in the page when the input gets focus. This PR changes the font size from 14px to 16px on mobile to avoid extra zooming.

## Screenshot with the current 14px font size

<img width="349" alt="input-14px" src="https://user-images.githubusercontent.com/53923/134158367-f8ff9610-8b99-436f-bf75-27dc42c8dbdd.png">

When focusing on the input:

<img width="350" alt="input-14px-focus" src="https://user-images.githubusercontent.com/53923/134158385-ecc3b230-9f9b-45ad-b503-16a0a623b6be.png">

## Screenshot with the proposed 16px font size

<img width="349" alt="input-16px" src="https://user-images.githubusercontent.com/53923/134158453-e3578a52-8cb3-4d3b-91dd-4852c2b51dfc.png">

