### PR TITLE
Update comment about scroll into view with hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+- [change] Update comment about how scrollIntoView works with links using hash.
+  [#1484](https://github.com/sharetribe/ftw-daily/pull/1484)
 - [fix] Account pages: mobile tab navigation should only scroll horizontally
   [#1481](https://github.com/sharetribe/ftw-daily/pull/1481)
 - [fix] Temporarily disallow Node v17, since it causes issues with dependencies.

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -45,16 +45,15 @@ const setPageScrollPosition = location => {
   } else {
     const el = document.querySelector(location.hash);
     if (el) {
-      // Found element with the given fragment identifier, scrolling
-      // to that element.
+      // Found element from the current page with the given fragment identifier,
+      // scrolling to that element.
       //
-      // NOTE: This isn't foolproof. It works when navigating within
-      // the application between pages and within a single page. It
-      // also works with the initial page load. However, it doesn't
-      // seem work work properly when refreshing the page, at least
-      // not in Chrome.
-      //
-      // TODO: investigate why the scrolling fails on refresh
+      // NOTE: This only works on in-app navigation within the same page.
+      // If smooth scrolling is needed between different pages, one needs to wait
+      //   1. loadData fetch and
+      //   2. code-chunk fetch
+      // before making el.scrollIntoView call.
+
       el.scrollIntoView({
         block: 'start',
         behavior: 'smooth',


### PR DESCRIPTION
Due to loadData and code-splitting, scrollIntoView feature related to hash-links is pretty limited.