### PR TITLE
Fix checkout process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2021-XX-XX
 
+- [fix] Fix bugs in checkout process:
+
+  - Submit button was enabled prematurely for onetime payments
+  - Toggling between default card and onetime payment flows was not working correctly in case of
+    error (e.g. network error).
+  - Calling Stripe.confirmCardPayment when status is requires_capture is unnecessary.
+
+  [#1486](https://github.com/sharetribe/ftw-daily/pull/1486)
+
 - [change] Update many dependencies. See full list in the package.json changes in the PR.
   [#1483](https://github.com/sharetribe/ftw-daily/pull/1483)
 - [fix] Double click issue. Show dedicated message, when current user doesn't have a pending email

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -282,9 +282,8 @@ export class CheckoutPageComponent extends Component {
       const { stripe, card, billingDetails, paymentIntent } = handlePaymentParams;
       const stripeElementMaybe = selectedPaymentFlow !== USE_SAVED_CARD ? { card } : {};
 
-      // Note: payment_method could be set here for USE_SAVED_CARD flow.
-      // { payment_method: stripePaymentMethodId }
-      // However, we have set it already on API side, when PaymentIntent was created.
+      // Note: For basic USE_SAVED_CARD scenario, we have set it already on API side, when PaymentIntent was created.
+      // However, the payment_method is save here for USE_SAVED_CARD flow if customer first attempted onetime payment
       const paymentParams =
         selectedPaymentFlow !== USE_SAVED_CARD
           ? {
@@ -293,7 +292,7 @@ export class CheckoutPageComponent extends Component {
                 card: card,
               },
             }
-          : {};
+          : { payment_method: stripePaymentMethodId };
 
       const params = {
         stripePaymentIntentClientSecret,

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -169,6 +169,30 @@ const getPaymentMethod = (selectedPaymentMethod, hasDefaultPaymentMethod) => {
     : selectedPaymentMethod;
 };
 
+// Should we show onetime payment fields and does StripeElements card need attention
+const checkOnetimePaymentFields = (
+  cardValueValid,
+  selectedPaymentMethod,
+  hasDefaultPaymentMethod,
+  hasHandledCardPayment
+) => {
+  const useDefaultPaymentMethod =
+    selectedPaymentMethod === 'defaultCard' && hasDefaultPaymentMethod;
+  // Billing details are known if we have already handled card payment or existing default payment method is used.
+  const billingDetailsKnown = hasHandledCardPayment || useDefaultPaymentMethod;
+
+  // If onetime payment is used, check that the StripeElements card has valid value.
+  const oneTimePaymentMethods = ['onetimeCardPayment', 'replaceCard'];
+  const useOnetimePaymentMethod = oneTimePaymentMethods.includes(selectedPaymentMethod);
+  const onetimePaymentNeedsAttention =
+    !billingDetailsKnown && !(useOnetimePaymentMethod && cardValueValid);
+
+  return {
+    onetimePaymentNeedsAttention,
+    showOnetimePaymentFields: useOnetimePaymentMethod,
+  };
+};
+
 const initialState = {
   error: null,
   cardValueValid: false,
@@ -255,6 +279,7 @@ class StripePaymentForm extends Component {
       this.card.removeEventListener('change', this.handleCardValueChange);
       this.card.unmount();
       this.card = null;
+      this.setState({ cardValueValid: false });
     }
     this.setState({ paymentMethod: changedTo });
   }
@@ -292,8 +317,14 @@ class StripePaymentForm extends Component {
     } = this.props;
     const { initialMessage } = values;
     const { cardValueValid, paymentMethod } = this.state;
-    const billingDetailsKnown = hasHandledCardPayment || defaultPaymentMethod;
-    const onetimePaymentNeedsAttention = !billingDetailsKnown && !cardValueValid;
+    const hasDefaultPaymentMethod = defaultPaymentMethod.id;
+    const selectedPaymentMethod = getPaymentMethod(paymentMethod, hasDefaultPaymentMethod);
+    const { onetimePaymentNeedsAttention } = checkOnetimePaymentFields(
+      cardValueValid,
+      selectedPaymentMethod,
+      hasDefaultPaymentMethod,
+      hasHandledCardPayment
+    );
 
     if (inProgress || onetimePaymentNeedsAttention) {
       // Already submitting or card value incomplete/invalid
@@ -338,8 +369,17 @@ class StripePaymentForm extends Component {
 
     const ensuredDefaultPaymentMethod = ensurePaymentMethodCard(defaultPaymentMethod);
     const billingDetailsNeeded = !(hasHandledCardPayment || confirmPaymentError);
-    const billingDetailsKnown = hasHandledCardPayment || ensuredDefaultPaymentMethod;
-    const onetimePaymentNeedsAttention = !billingDetailsKnown && !this.state.cardValueValid;
+
+    const { cardValueValid, paymentMethod } = this.state;
+    const hasDefaultPaymentMethod = ensuredDefaultPaymentMethod.id;
+    const selectedPaymentMethod = getPaymentMethod(paymentMethod, hasDefaultPaymentMethod);
+    const { onetimePaymentNeedsAttention, showOnetimePaymentFields } = checkOnetimePaymentFields(
+      cardValueValid,
+      selectedPaymentMethod,
+      hasDefaultPaymentMethod,
+      hasHandledCardPayment
+    );
+
     const submitDisabled = invalid || onetimePaymentNeedsAttention || submitInProgress;
     const hasCardError = this.state.error && !submitInProgress;
     const hasPaymentErrors = confirmCardPaymentError || confirmPaymentError;
@@ -391,19 +431,11 @@ class StripePaymentForm extends Component {
     );
 
     const hasStripeKey = config.stripe.publishableKey;
-    const showPaymentMethodSelector = ensuredDefaultPaymentMethod.id;
-    const selectedPaymentMethod = getPaymentMethod(
-      this.state.paymentMethod,
-      showPaymentMethodSelector
-    );
-    const showOnetimePaymentFields = ['onetimeCardPayment', 'replaceCard'].includes(
-      selectedPaymentMethod
-    );
     return hasStripeKey ? (
       <Form className={classes} onSubmit={handleSubmit} enforcePagePreloadFor="OrderDetailsPage">
         {billingDetailsNeeded && !loadingData ? (
           <React.Fragment>
-            {showPaymentMethodSelector ? (
+            {hasDefaultPaymentMethod ? (
               <PaymentMethodSelector
                 cardClasses={cardClasses}
                 formId={formId}

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -317,7 +317,7 @@ class StripePaymentForm extends Component {
     } = this.props;
     const { initialMessage } = values;
     const { cardValueValid, paymentMethod } = this.state;
-    const hasDefaultPaymentMethod = defaultPaymentMethod.id;
+    const hasDefaultPaymentMethod = defaultPaymentMethod?.id;
     const selectedPaymentMethod = getPaymentMethod(paymentMethod, hasDefaultPaymentMethod);
     const { onetimePaymentNeedsAttention } = checkOnetimePaymentFields(
       cardValueValid,


### PR DESCRIPTION
Issues:
  - Submit button was enabled prematurely for onetime payments. 
    It didn't check if stripeElements aka card number field was filled.
  - Changing from onetime payment to default card was not working correctly in case of error (e.g. network error).
  - Calling _stripe.confirmCardPayment_ when status is _requires_capture_ is unnecessary.
    >  400 "You cannot confirm this PaymentIntent because it has a status of requires_capture. Only a PaymentIntent with one of the following statuses may be confirmed: requires_confirmation, requires_action."
    

_Note_: these are cherry-picked commits from FTW-product:
  - [PR 111](https://github.com/sharetribe/ftw-product/pull/111)
  - [PR 120](https://github.com/sharetribe/ftw-product/pull/120)
  - [PR 121](https://github.com/sharetribe/ftw-product/pull/121)

    (Changelog updates were not included)