### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [fix] Setting multiple environment variables in Windows requires using the set command before each
+  individual variable. Updated the 'for windows users' section in documentation.
+  [#1491](https://github.com/sharetribe/ftw-daily/pull/1491)
 - [add] Code comment about "REACT_APP" prefix in environment variables.
   [#1492](https://github.com/sharetribe/ftw-daily/pull/1492)
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Change `export` to `set` in the package.json file if you're using Windows/DOS. Y
 change to "dev" and "dev-sever" commands.
 
 ```
-"dev": "yarn run config-check&&set NODE_ENV=development REACT_APP_DEV_API_SERVER_PORT=3500&&concurrently --kill-others \"yarn run dev-frontend\" \"yarn run dev-backend\""
+"dev": "yarn run config-check&&set NODE_ENV=development&& set REACT_APP_DEV_API_SERVER_PORT=3500&&concurrently --kill-others \"yarn run dev-frontend\" \"yarn run dev-backend\""
 ```
 
 ```
-"dev-server": "set NODE_ENV=development PORT=4000 REACT_APP_CANONICAL_ROOT_URL=http://localhost:4000&&yarn run build&&nodemon --watch server server/index.js"
+"dev-server": "set NODE_ENV=development&& set PORT=4000&& set REACT_APP_CANONICAL_ROOT_URL=http://localhost:4000&&yarn run build&&nodemon --watch server server/index.js"
 ```
 
 We strongly recommend installing


### PR DESCRIPTION
Windows users commonly report the following error message when running `yarn run dev` or `dev-server`:
`RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536`

Setting multiple environment variables in Windows requires using the set command before each individual variable. Updated the 'for windows users' section in documentation.