### PR TITLE
Add comment about REACT_APP prefix

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,3 +1,6 @@
+# Environment variables for the client app.
+# Note that variables, that start with "REACT_APP" prefix, are exposed to the public web.
+# https://create-react-app.dev/docs/adding-custom-environment-variables
 
 # Mandatory configuration
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ way to update this template, but currently, we follow a pattern:
 
 ---
 
-## Upcoming version 2021-XX-XX
+## Upcoming version 2022-XX-XX
+
+- [add] Code comment about "REACT_APP" prefix in environment variables.
+  [#1492](https://github.com/sharetribe/ftw-daily/pull/1492)
 
 ## [v8.4.0] 2021-12-02
 


### PR DESCRIPTION
"REACT_APP" prefix means that the environment variable is bundled into the **web** app - it's available in a browser.
https://create-react-app.dev/docs/adding-custom-environment-variables