### PR TITLE
Modal: portal could use hack for 100vh to have correct height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [fix] Portal version of Modals couldn't use 100vh on mobile Safari. Safari changes the window's
+  height based on if the location bar is squeezed or not (and that depends on scroll-effect).
+  [#1501](https://github.com/sharetribe/ftw-daily/pull/1501)
 - [fix] Setting multiple environment variables in Windows requires using the set command before each
   individual variable. Updated the 'for windows users' section in documentation.
   [#1491](https://github.com/sharetribe/ftw-daily/pull/1491)

--- a/src/components/BookingPanel/BookingPanel.module.css
+++ b/src/components/BookingPanel/BookingPanel.module.css
@@ -9,7 +9,7 @@
 
   @media (--viewportMedium) {
     flex-basis: 576px;
-    height: 100%;
+    height: unset;
     padding: var(--modalPaddingMedium);
     background-color: var(--matterColorLight);
     margin-top: 12.5vh;
@@ -98,10 +98,10 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  margin: 0 0 84px 0;
+  padding: 0;
 
   @media (--viewportMedium) {
-    margin: 0;
+    padding: 0;
     min-height: 400px;
   }
 

--- a/src/components/FieldDateRangeInput/DateRangeInput.module.css
+++ b/src/components/FieldDateRangeInput/DateRangeInput.module.css
@@ -29,6 +29,7 @@
 
   & :global(.DateInput_input) {
     @apply --marketplaceH4FontStyles;
+    font-size: 16px;
     padding: 0;
     margin: 0;
     border: 0;

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -2,13 +2,6 @@
 
 /* Content is visible as modal layer */
 .isOpen {
-  display: flex;
-  flex-direction: column;
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   width: 100%;
   z-index: 100;
 
@@ -42,6 +35,34 @@
       min-height: auto;
       height: auto;
     }
+  }
+}
+
+.isOpenInPlace {
+  composes: isOpen;
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.isOpenInPortal {
+  composes: isOpen;
+  display: block;
+  height: calc(var(--vh, 1vh) * 100);
+  position: absolute;
+
+  @media (--viewportMedium) {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
   }
 }
 

--- a/src/forms/BookingDatesForm/BookingDatesForm.module.css
+++ b/src/forms/BookingDatesForm/BookingDatesForm.module.css
@@ -15,7 +15,7 @@
 
 .priceBreakdownContainer {
   padding: 0 24px;
-  margin-bottom: 40px;
+  margin-bottom: 24px;
 
   @media (--viewportMedium) {
     padding: 0;


### PR DESCRIPTION
Portal version of Modals couldn't use 100vh on mobile Safari. Safari changes the window's height based on if the location bar is squeezed or not (and that depends on scroll-effect).

Basically, this fix:
https://css-tricks.com/the-trick-to-viewport-units-on-mobile/#css-custom-properties-the-trick-to-correct-sizing