### PR TITLE
New release v8.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+## [v8.4.1] 2022-03-16
+
 - [fix] Portal version of Modals couldn't use 100vh on mobile Safari. Safari changes the window's
   height based on if the location bar is squeezed or not (and that depends on scroll-effect).
   [#1501](https://github.com/sharetribe/ftw-daily/pull/1501)
@@ -22,6 +24,8 @@ way to update this template, but currently, we follow a pattern:
   [#1491](https://github.com/sharetribe/ftw-daily/pull/1491)
 - [add] Code comment about "REACT_APP" prefix in environment variables.
   [#1492](https://github.com/sharetribe/ftw-daily/pull/1492)
+
+  [v8.4.1]: https://github.com/sharetribe/ftw-daily/compare/v8.4.0...v8.4.1
 
 ## [v8.4.0] 2021-12-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
- [fix] Portal version of Modals couldn't use 100vh on mobile Safari. Safari changes the window's
  height based on if the location bar is squeezed or not (and that depends on scroll-effect).
  [#1501](https://github.com/sharetribe/ftw-daily/pull/1501)
- [fix] Setting multiple environment variables in Windows requires using the set command before each
  individual variable. Updated the 'for windows users' section in the documentation.
  [#1491](https://github.com/sharetribe/ftw-daily/pull/1491)
- [add] Code comment about "REACT_APP" prefix in environment variables.
  [#1492](https://github.com/sharetribe/ftw-daily/pull/1492)
