### PR TITLE
Remove GA  analytics.js add gtag.js script

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -51,6 +51,10 @@ REACT_APP_CSP=report
 # REACT_APP_SENTRY_DSN=change-me
 # BASIC_AUTH_USERNAME=sharetribe
 # BASIC_AUTH_PASSWORD=secret
+
+# This is GA4 id, which should start with 'G-' prefix.
+# You should also turn "Enhanced measurements" off from GA.
+# https://support.google.com/analytics/answer/9216061
 # REACT_APP_GOOGLE_ANALYTICS_ID=change-me
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [change] Google Analytics: remove Universal Analytics and start supporting GA4.
+
+  NOTE: you need to update the Google Analytics id to GA4's id (starting with 'G-' prefix).
+
+  [#1508](https://github.com/sharetribe/ftw-daily/pull/1508)
+
 - [change] Update some outdated dependencies.
   [#1514](https://github.com/sharetribe/ftw-daily/pull/1514)
 

--- a/server/csp.js
+++ b/server/csp.js
@@ -32,6 +32,7 @@ const defaultDirectives = {
     'events.mapbox.com',
 
     // Google Analytics
+    '​www.​googletagm­anager.​com',
     'www.google-analytics.com',
     'stats.g.doubleclick.net',
 
@@ -59,6 +60,7 @@ const defaultDirectives = {
     '*.ggpht.com',
 
     // Google Analytics
+    'www.googletagmanager.com',
     'www.google.com',
     'www.google-analytics.com',
     'stats.g.doubleclick.net',
@@ -72,6 +74,7 @@ const defaultDirectives = {
     data,
     'maps.googleapis.com',
     'api.mapbox.com',
+    '​www.​googletagm­anager.​com',
     '*.google-analytics.com',
     'js.stripe.com',
   ],

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -64,8 +64,8 @@ const setPageScrollPosition = location => {
 
 const handleLocationChanged = (dispatch, location) => {
   setPageScrollPosition(location);
-  const url = canonicalRoutePath(routeConfiguration(), location);
-  dispatch(locationChanged(location, url));
+  const path = canonicalRoutePath(routeConfiguration(), location);
+  dispatch(locationChanged(location, path));
 };
 
 /**

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -8,9 +8,9 @@ export const createMiddleware = handlers => () => next => action => {
   const { type, payload } = action;
 
   if (type === LOCATION_CHANGED) {
-    const { canonicalUrl } = payload;
+    const { canonicalPath } = payload;
     handlers.forEach(handler => {
-      handler.trackPageView(canonicalUrl);
+      handler.trackPageView(canonicalPath);
     });
   }
 

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -3,14 +3,15 @@ import { LOCATION_CHANGED } from '../ducks/Routing.duck';
 // Create a Redux middleware from the given analytics handlers. Each
 // handler should have the following methods:
 //
-// - trackPageView(url): called when the URL is changed
-export const createMiddleware = handlers => () => next => action => {
+// - trackPageView(canonicalPath, previousPath): called when the URL is changed
+export const createMiddleware = handlers => store => next => action => {
   const { type, payload } = action;
 
   if (type === LOCATION_CHANGED) {
+    const previousPath = store?.getState()?.Routing?.currentCanonicalPath;
     const { canonicalPath } = payload;
     handlers.forEach(handler => {
-      handler.trackPageView(canonicalPath);
+      handler.trackPageView(canonicalPath, previousPath);
     });
   }
 

--- a/src/analytics/handlers.js
+++ b/src/analytics/handlers.js
@@ -4,16 +4,30 @@ export class LoggingAnalyticsHandler {
   }
 }
 
+// Google Analytics 4 (GA4) using gtag.js script, which is included in server/rendered.js
+// Note: the script is only available locally when running "yarn run dev-server"
 export class GoogleAnalyticsHandler {
-  constructor(ga) {
-    if (typeof ga !== 'function') {
-      throw new Error('Variable `ga` missing for Google Analytics');
+  constructor(gtag) {
+    if (typeof gtag !== 'function') {
+      throw new Error('Variable `gtag` missing for Google Analytics');
     }
-    this.ga = ga;
+    this.gtag = gtag;
   }
-  trackPageView(url) {
-    // https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications#tracking_virtual_pageviews
-    this.ga('set', 'page', url);
-    this.ga('send', 'pageview');
+  trackPageView(canonicalPath, previousPath) {
+    // GA4 property. Manually send page_view events
+    // https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications
+    // Note 1: You should turn "Enhanced measurement" off.
+    //         It attaches own listeners to elements and that breaks in-app navigation.
+    // Note 2: If previousPath is null (just after page load), gtag script sends page_view event automatically.
+    //         Only in-app navigation needs to be sent manually from SPA.
+    // Note 3: Timeout is needed because gtag script picks up <title>,
+    //         and location change event happens before initial rendering.
+    if (previousPath) {
+      window.setTimeout(() => {
+        this.gtag('event', 'page_view', {
+          page_path: canonicalPath,
+        });
+      }, 300);
+    }
   }
 }

--- a/src/ducks/Routing.duck.js
+++ b/src/ducks/Routing.duck.js
@@ -6,7 +6,7 @@ export const LOCATION_CHANGED = 'app/Routing/LOCATION_CHANGED';
 
 const initialState = {
   currentLocation: null,
-  currentCanonicalUrl: null,
+  currentCanonicalPath: null,
 };
 
 export default function routingReducer(state = initialState, action = {}) {
@@ -16,7 +16,7 @@ export default function routingReducer(state = initialState, action = {}) {
       return {
         ...state,
         currentLocation: payload.location,
-        currentCanonicalUrl: payload.canonicalUrl,
+        currentCanonicalPath: payload.canonicalPath,
       };
 
     default:
@@ -26,7 +26,7 @@ export default function routingReducer(state = initialState, action = {}) {
 
 // ================ Action creators ================ //
 
-export const locationChanged = (location, canonicalUrl) => ({
+export const locationChanged = (location, canonicalPath) => ({
   type: LOCATION_CHANGED,
-  payload: { location, canonicalUrl },
+  payload: { location, canonicalPath },
 });

--- a/src/index.js
+++ b/src/index.js
@@ -81,14 +81,19 @@ const setupAnalyticsHandlers = () => {
     handlers.push(new LoggingAnalyticsHandler());
   }
 
-  // Add Google Analytics handler if tracker ID is found
+  // Add Google Analytics 4 (GA4) handler if tracker ID is found
   if (process.env.REACT_APP_GOOGLE_ANALYTICS_ID) {
-    if (window?.ga) {
-      handlers.push(new GoogleAnalyticsHandler(window.ga));
+    if (window?.gtag) {
+      handlers.push(new GoogleAnalyticsHandler(window.gtag));
     } else {
       // Some adblockers (e.g. Ghostery) might block the Google Analytics integration.
       console.warn(
-        'Google Analytics (window.ga) is not available. It might be that your adblocker is blocking it.'
+        'Google Analytics (window.gtag) is not available. It might be that your adblocker is blocking it.'
+      );
+    }
+    if (process.env.REACT_APP_GOOGLE_ANALYTICS_ID.indexOf('G-') !== 0) {
+      console.warn(
+        'Google Analytics 4 (GA4) should have measurement id that starts with "G-" prefix'
       );
     }
   }


### PR DESCRIPTION
## Google analytics script changed
Universal Analytics (analytics.js + measurement id starting with _"UA"_ prefix) is sunsetting in 2023.

This PR removes UA integration and adds Google Analytics 4 (GA4) instead: 
gtag.js script + it expects measurement id starting with _"G-"_ prefix.

In addition, the `trackPageView` method of analytics handlers now gets 2 parameters: 
- The first parameter still holds the **canonicalPath** of the (next) page.
- The second parameter is a new one: it contains information about the previous path.
  This is needed for GA4, which by default always sends page_view event on page load, but in-app navigation after that should be sent manually. If the previous path is non-existent, this manual call should be omitted.

### There are some notable issues related to GA4

#### Enhanced measurements
By default, **Enhanced measurements** are _on_. This means that gtag.js adds its own code to all kinds of event sources like links `<a>`. This seems to be slow code and most likely breaks in-app navigation. 

Our links look like normal links but React Router adds its own click event listeners to them and bypasses the default link behavior that causes full page load. With the code attached by GA4, the event handling is too slow and the code probably doesn't prevent the default behavior (which should be prevented - otherwise, the event gets bubbled up to default behavior).

It's probably best to turn Enhanced measurements _off_.
![Screenshot 2022-04-22 at 11 57 56](https://user-images.githubusercontent.com/717315/164672866-a0b073ba-4eea-4709-8b5b-56d78c682ca8.png)
https://support.google.com/analytics/answer/9216061

If that's not an option, then you should at least turn 
- **Outbound clicks** events off and 
- **Page changes based on browser history events** off.

![Screenshot 2022-04-22 at 11 35 07](https://user-images.githubusercontent.com/717315/164673539-4abfab9e-ba20-4683-b20a-3393def76634.png)

#### Page title is sent to GA4

This is problematic because FTW's the routing first changes the location and then on a new location it renders the page and URL parameters (path params, search params, hash) are taken into account during rendering.

So, history.pushState happens before the page title (`<title>`) is rendered. Therefore, we have used setTimeout to give the page 300 milliseconds to render something after the 'LOCATION_CHANGED' action.