### PR TITLE
Fix accidental invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+## [v8.6.2] 2022-05-19
+
+- [fix] There was also invalid characters (zero-width space) on added directive
+  [#1517](https://github.com/sharetribe/ftw-daily/pull/1517)
+
+  [v8.6.2]: https://github.com/sharetribe/ftw-daily/compare/v8.6.1...v8.6.2
+
 ## [v8.6.1] 2022-05-19
 
 - [fix] undefined REACT_APP_GOOGLE_ANALYTICS_ID caused an error.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.6.0",
+  "version": "8.6.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/server/csp.js
+++ b/server/csp.js
@@ -32,7 +32,7 @@ const defaultDirectives = {
     'events.mapbox.com',
 
     // Google Analytics
-    '​www.​googletagm­anager.​com',
+    'www.googletagmanager.com',
     'www.google-analytics.com',
     'stats.g.doubleclick.net',
 
@@ -74,7 +74,7 @@ const defaultDirectives = {
     data,
     'maps.googleapis.com',
     'api.mapbox.com',
-    '​www.​googletagm­anager.​com',
+    'www.googletagmanager.com',
     '*.google-analytics.com',
     'js.stripe.com',
   ],


### PR DESCRIPTION
There were some zero-width characters in the 'www.googletagmanager.com' rule for CSP directives.