### PR TITLE
Proof of Concept (not sure if this ever gets merged though)

### DIFF
--- a/src/components/ImageCarousel/ImageCarousel.js
+++ b/src/components/ImageCarousel/ImageCarousel.js
@@ -97,19 +97,47 @@ class ImageCarousel extends Component {
       [css.imageLoading]: !currentImageIsLoaded,
     });
 
+    const arrayLength = images.length;
+    const currentIndex = this.state.selectedImageIndex;
+    const prevIndex = (currentIndex + arrayLength - 1) % arrayLength;
+    const nextIndex = (currentIndex + 1) % arrayLength;
     return (
       <div className={classes}>
-        <div className={css.imageWrapper}>
-          <IconSpinner className={loadingIconClasses} />
-          <ResponsiveImage
-            className={imageClasses}
-            alt={imageAltText}
-            image={images[this.state.selectedImageIndex]}
-            onLoad={markImageLoaded(this.state.selectedImageIndex)}
-            onError={markImageLoaded(this.state.selectedImageIndex)}
-            variants={['scaled-small', 'scaled-medium', 'scaled-large', 'scaled-xlarge']}
-            sizes="(max-width: 767px) 100vw, 80vw"
-          />
+        <div className={css.imageViewport}>
+          <div className={css.imageArray}>
+            <div className={css.imageWrapper}>
+              <IconSpinner className={loadingIconClasses} />
+              <ResponsiveImage
+                className={css.image}
+                alt={imageAltText}
+                image={images[prevIndex]}
+                variants={['scaled-small', 'scaled-medium', 'scaled-large', 'scaled-xlarge']}
+                sizes="(max-width: 767px) 100vw, 80vw"
+              />
+            </div>
+            <div className={css.imageWrapper}>
+              <IconSpinner className={loadingIconClasses} />
+              <ResponsiveImage
+                className={imageClasses}
+                alt={imageAltText}
+                image={images[currentIndex]}
+                onLoad={markImageLoaded(currentIndex)}
+                onError={markImageLoaded(currentIndex)}
+                variants={['scaled-small', 'scaled-medium', 'scaled-large', 'scaled-xlarge']}
+                sizes="(max-width: 767px) 100vw, 80vw"
+              />
+            </div>
+            <div className={css.imageWrapper}>
+              <IconSpinner className={loadingIconClasses} />
+              <ResponsiveImage
+                className={css.image}
+                alt={imageAltText}
+                image={images[nextIndex]}
+                variants={['scaled-small', 'scaled-medium', 'scaled-large', 'scaled-xlarge']}
+                sizes="(max-width: 767px) 100vw, 80vw"
+              />
+            </div>
+          </div>
         </div>
         {imageIndex}
         {prevButton}

--- a/src/components/ImageCarousel/ImageCarousel.module.css
+++ b/src/components/ImageCarousel/ImageCarousel.module.css
@@ -11,12 +11,27 @@
   }
 }
 
-.imageWrapper {
+.imageViewport {
   position: relative;
-  display: flex;
-  flex-direction: row;
   width: 100%;
   height: 100%;
+  overflow: hidden;
+}
+.imageArray {
+  width: 300%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+
+  position: absolute;
+  left: -100%;
+}
+
+.imageWrapper {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .imageIndex {
@@ -111,6 +126,8 @@
 .image {
   /* Fit image in the available space as big as possible, keeping the aspect ratio */
   object-fit: contain;
+  width: 100%;
+  height: 100%;
 }
 
 .imageLoading {


### PR DESCRIPTION
## Preloading next & prev ResponsiveImages on the ImageCarousel.

Because the browser chooses which image variant it actually fetches, we can't just preload the image itself but we need to add actual ResponsiveImage components into the DOM to make browser understand that *Next* and *Prev* buttons are going to load new images. 

Note: I have not done any cross-browser testing for this PoC.