### PR TITLE
New release: v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+## [v9.0.0] 2022-07-11
+
+This is a major release since it includes a major update to sharetribe-scripts aka our fork of
+Create React App.It includes major update to Webpack (v4 > v5) and PostCSS (v7 > v8). These caused
+some advanced CSS syntax to be invalid - and therefore some changes must be done to CSS files.
+
+- CSS Property Sets are deprecated and the related file is removed from the codebase
+- Custom media queries file need to be imported in all the files, that use them.
+
+Read more from PR: https://github.com/sharetribe/ftw-daily/pull/1531
+
+Changes:
+
 - [change] sharetribe-scripts is updated to v6.0.0. This causes a new major release for FTW
   templates. Because most of the CSS files need to be updated!
   [#1531](https://github.com/sharetribe/ftw-daily/pull/1531)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.6.2",
+  "version": "9.0.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
NOTE: THIS IS GOING TO CAUSE A MAJOR VERSION CHANGE TO TEMPLATES.

## This PR updates sharetribe-scripts to the next major version.
*sharetribe-scripts* is a fork of Create React App (CRA) repository and specifically react-scripts is modified to support server-side rendering, code-splitting, and certain PostCSS plugins that we chose to include years ago. (E.g. introduced CSS Modules before CRA took the same approach.)

### This update is actually an update from [CRA 4.0.2 to v5.0.1](https://github.com/sharetribe/create-react-app/pull/24) 
The breaking changes are in [v5.0.0](https://github.com/facebook/create-react-app/blob/main/CHANGELOG.md#500-2021-12-14)

> **Highlights** from CRA update:
> - webpack 5 (https://github.com/facebook/create-react-app/pull/11201)
> - Jest 27 (#11338)
> - ESLint 8 (#11375)
> - PostCSS 8 (#11121)
> - Fast Refresh improvements and bug fixes (https://github.com/facebook/create-react-app/pull/11105)
> - Support for Tailwind (https://github.com/facebook/create-react-app/pull/11717)
> - Improved package manager detection (https://github.com/facebook/create-react-app/pull/11322)
> - Unpinned all dependencies for better compatibility with other tools (https://github.com/facebook/create-react-app/pull/11474)
> - Dropped support for Node 10 and 12
> 

Note: we haven't explored Tailwind support since it would mean a complete rewrite for the FTW templates. In addition, CSS Modules make it easier for customizers to learn a big codebase like FTW (i.e. which component is responsible for a different sections of DOM, etc.).

---

## Consequences

Major updates to Webpack (v4 > v5) and PostCSS (v7 > v8), were the most worksome for FTW templates.

- The upper restriction of Node.js engine _"version earlier than v17"_ has been lifted!

- [Loadable components](https://github.com/gregberge/loadable-components) was updated
  - FTW and other client apps should update their part of Loadable components too
    - "@loadable/component": "^5.15.2",
    - "@loadable/server": "^5.15.2",

- You should add `@import`for **customMediaQueries.css** file.
  - E.g. `@import '../../styles/customMediaQueries.css';`
  - Some parallelism has increased in the build process and postcss-import wasn't included without it being explicitly mentioned per CSS file.

- ***src/index.js*** was refactored.
  - We rearranged the module imports
    - *marketplaceDefaults.css* was introduced first before any of the components were imported.
    - This ensures that the content of marketplaceDefaults.css is first in the built CSS file (main chunk).
      (The order of classes in CSS files affects declaration overrides.)  

- [postcss-apply](https://github.com/pascalduez/postcss-apply) plugin is not working anymore
  - It's been deprecated for a long time because W3C decided to not go forward with that feature suggestion
  - **You should migrate away from postcss-apply syntax (aka CSS Property _Sets_)**
    - Most of the code changes in this PR are about migrating away from CSS Property Sets
  - However, we have introduced a _**naive** custom version_ of postcss-apply as a private plugin to give more time to migrate away.

    Most of the previous CSS Property Sets are turned into CSS classes in the *marketplaceDefaults.css* file.
    So, most of the time the change is minimal:
    ```
    .author {
      @apply --marketplaceH4FontStyles;
    }
    ```
    ```
    .author {
      composes: h4 from global;
    }
    ```
    Unfortunately, there's one problem that doesn't make it that straightforward. **The order of the plain CSS classes in the *marketplaceDefaults.css* file defines which classes override each other.** (The [composes feature](https://github.com/css-modules/css-modules#composition) just includes those class names to DOM element - not their content.) Therefore, if multiple @apply rules are used inside the CSS module class, you need to check if there are overwrites between declarations of those Sets.
    
    Button styling included almost always some overrides. We decided to split buttons styles into smaller chunks that can be combined:
    ```
    .buttonLink {
      @apply --marketplaceButtonStyles;
    }
    .buttonLinkPrimary {
      @apply --marketplaceButtonStylesPrimary;
    }
    
    .buttonLinkSecondary {
      @apply --marketplaceButtonStylesSecondary;
    }

    ```
    New syntax:
    ```
    .buttonLink {
      composes: button buttonFont buttonText buttonBorders buttonColors from global;
    }
    .buttonLinkPrimary {
      composes: button buttonFont buttonText buttonBorders buttonColorsPrimary from global;
    }
    
    .buttonLinkSecondary {
      composes: button buttonFont buttonText buttonBordersSecondary buttonColorsSecondary from global;
    }
    ```
    This might be a bit controversial, but it introduces fewer CSS overrides. Of course, you are free to customize this to your liking.

---

## Potential issues that you might encounter if taking an update from upstream

### Old version of @babel/runtime
```
Module not found: Error: Can't resolve './defineProperty' in '/Users/vesaluusua/st/ftw-daily/node_modules/redux/node_modules/@babel/runtime/helpers/esm'
Did you mean 'defineProperty.js'?
```
Redux has sub-dependency to @babel/runtime. An old version of that package doesn't handle ES Modules well. You might need to call `yarn upgrade redux` after `yarn install` to update Redux sub dependencies to the latest in yarn.lock file. 
https://github.com/reduxjs/redux/issues/4174

### customMediaQueries.css was not @imported in the file that uses them

You should be able to find correct files by grepping files that *don't* contain  "customMediaQueries" but which contain "--viewport".

In OSX, that could be done in Terminal with:
```
grep -r --include \*.module.css -L customMediaQueries ./src | xargs grep -l '\-\-viewport'
```

### Missing *propertySets.css* file and your custom CSS Property Sets

You should consider if you want to refactor your custom @apply rules (i.e. migrate away as recommended) or reintroduce / revert the deletion of the *propertySets.css* file.

### Wrong syntax for CSS Property Sets (postcss-apply)

Some of the definitions of CSS Property Sets in the FTW codebase used a wrong syntax to define them. The previous way how PostCSS v7 parsed CSS files to the AST (Abstract Syntax Tree) didn't care about that, but PostCSS v8 changed the parsing logic.

🚫 Invalid:
```
--marketplaceModalTitleStyles {
  font-size: 30px;
}
```

✅ Valid:
```
--marketplaceModalTitleStyles: {
  font-size: 30px;
}
```

You should only face this issue if you continue to use CSS Property Sets. However, you should consider them as deprecated and migrate away.

### There are a couple of warnings with `yarn run dev`

```shell
[0] (node:58738) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
[0] (Use `node --trace-deprecation ...` to show where the warning was created)
[0] (node:58738) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
```

This is hopefully fixed in the next release:
https://github.com/facebook/create-react-app/pull/11862
