### PR TITLE
Add cookie_flags and relax google analytics domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [fix] Add cookie_flags and relax google analytics domain
+  [#1538](https://github.com/sharetribe/ftw-daily/pull/1538)
 - [fix] the import of customMediaQueries.css was somehow missed with these components:
   FieldReviewRating, SearchFiltersSecondary and TopbarMobileMenu.
   [#1537](https://github.com/sharetribe/ftw-daily/pull/1537)

--- a/server/csp.js
+++ b/server/csp.js
@@ -33,7 +33,7 @@ const defaultDirectives = {
 
     // Google Analytics
     'www.googletagmanager.com',
-    'www.google-analytics.com',
+    '*.google-analytics.com',
     'stats.g.doubleclick.net',
 
     'sentry.io',

--- a/server/renderer.js
+++ b/server/renderer.js
@@ -142,7 +142,9 @@ exports.render = function(requestUrl, context, data, renderApp, webExtractor) {
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
       
-        gtag('config', '${googleAnalyticsId}');
+        gtag('config', '${googleAnalyticsId}', {
+          cookie_flags: 'SameSite=None;Secure',
+        });
       </script>
     `;
   const googleAnalyticsScript = hasGoogleAnalyticsv4Id ? gtagScripts : '';


### PR DESCRIPTION
CSP: Relaxed connect-src directive for google analytics due to regional subdomains:
https://support.google.com/analytics/answer/11598602?hl=en

Firefox warned that GA cookies were missing the sameSite attribute:
> Cookie “_ga” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To know more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

https://stackoverflow.com/questions/62569419/how-to-set-secure-attribute-of-the-cookies-used-by-google-analytics-global-sit/62569420#62569420
