### PR TITLE
Remove unnecessary polyfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,18 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
-- Add the cross-env package to better support Windows command prompts
+- [delete] Remove unnecessary polyfills (dependencies might still use these)
+
+  - array-includes
+  - array.prototype.find
+  - object.entries
+  - object.values
+  - Number.parseFloat, Number.parseInt, Number.isNaN
+
+  [#1565](https://github.com/sharetribe/ftw-daily/pull/1565)
+
+- [add] Add the cross-env package to better support Windows command prompts
+  [#1555](https://github.com/sharetribe/ftw-daily/pull/1555)
 
 ## [v9.0.2] 2022-10-17
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@mapbox/polyline": "^1.1.1",
     "@sentry/browser": "^6.19.7",
     "@sentry/node": "^6.19.7",
-    "array-includes": "^3.1.5",
     "array.prototype.find": "^2.2.0",
     "autosize": "^5.0.1",
     "basic-auth": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lodash": "^4.17.21",
     "mapbox-gl-multitouch": "^1.0.3",
     "moment": "^2.29.4",
-    "object.entries": "^1.1.5",
     "object.values": "^1.1.5",
     "passport": "^0.5.3",
     "passport-facebook": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lodash": "^4.17.21",
     "mapbox-gl-multitouch": "^1.0.3",
     "moment": "^2.29.4",
-    "object.values": "^1.1.5",
     "passport": "^0.5.3",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@mapbox/polyline": "^1.1.1",
     "@sentry/browser": "^6.19.7",
     "@sentry/node": "^6.19.7",
-    "array.prototype.find": "^2.2.0",
     "autosize": "^5.0.1",
     "basic-auth": "^2.0.1",
     "body-parser": "^1.20.0",

--- a/src/util/polyfills.js
+++ b/src/util/polyfills.js
@@ -5,9 +5,6 @@
 // Smoothscroll
 require('smoothscroll-polyfill').polyfill();
 
-// Object.values
-require('object.values').shim();
-
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat
 if (typeof Number.parseFloat === 'undefined' && typeof window !== 'undefined') {
   Number.parseFloat = window.parseFloat;

--- a/src/util/polyfills.js
+++ b/src/util/polyfills.js
@@ -5,9 +5,6 @@
 // Smoothscroll
 require('smoothscroll-polyfill').polyfill();
 
-// Object.entries
-require('object.entries').shim();
-
 // Object.values
 require('object.values').shim();
 

--- a/src/util/polyfills.js
+++ b/src/util/polyfills.js
@@ -5,9 +5,6 @@
 // Smoothscroll
 require('smoothscroll-polyfill').polyfill();
 
-// [].find
-require('array.prototype.find').shim();
-
 // Object.entries
 require('object.entries').shim();
 

--- a/src/util/polyfills.js
+++ b/src/util/polyfills.js
@@ -5,9 +5,6 @@
 // Smoothscroll
 require('smoothscroll-polyfill').polyfill();
 
-// [].includes
-require('array-includes').shim();
-
 // [].find
 require('array.prototype.find').shim();
 

--- a/src/util/polyfills.js
+++ b/src/util/polyfills.js
@@ -3,24 +3,9 @@
 //
 
 // Smoothscroll
+// TODO: scroll-behaviour smooth was added to Safari on March 2022.
+//       We could consider removing this on 2023.
 require('smoothscroll-polyfill').polyfill();
-
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat
-if (typeof Number.parseFloat === 'undefined' && typeof window !== 'undefined') {
-  Number.parseFloat = window.parseFloat;
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt
-if (typeof Number.parseInt === 'undefined' && typeof window !== 'undefined') {
-  Number.parseInt = window.parseInt;
-}
-
-// NaN is the only value in javascript which is not equal to itself.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
-if (typeof Number.isNaN === 'undefined') {
-  // eslint-disable-next-line no-self-compare
-  Number.isNaN = value => value !== value;
-}
 
 // To support browsers that do not have Intl.PluralRules (e.g IE11 & Safari 12-),
 // - add npm packaged to package.json: "intl-pluralrules": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3846,16 +3846,6 @@ array.prototype.find@^2.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.19.0"
 
-array.prototype.find@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.2.0.tgz#153b8a28ad8965cd86d3117b07e6596af6f2880d"
-  integrity sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.19.4"
-    es-shim-unscopables "^1.0.0"
-
 array.prototype.flat@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
@@ -5750,7 +5740,7 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
-es-abstract@^1.19.2, es-abstract@^1.19.4, es-abstract@^1.19.5:
+es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
   integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==


### PR DESCRIPTION
Remove unnecessary polyfills (dependencies might still use these)

  - array-includes
  - array.prototype.find
  - object.entries
  - object.values
  - Number.parseFloat
  - Number.parseInt
  - Number.isNaN