### PR TITLE
Remove image bg-color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2022-XX-XX
 
+- [change] remove background-color from images (to allow opacity).
+  [#1590](https://github.com/sharetribe/ftw-daily/pull/1590)
 - [change] improve error handling possibilities on PageBuilder.
   [#1589](https://github.com/sharetribe/ftw-daily/pull/1589)
 - [fix] AuthenticationPage.duck.js: had wrong asset name.

--- a/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.module.css
+++ b/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.module.css
@@ -3,7 +3,6 @@
 
 .media {
   width: 100%;
-  background-color: var(--matterColorNegative); /* Loading state color for the images */
   border-radius: 8px;
   margin-bottom: 0;
 }

--- a/src/containers/PageBuilder/Primitives/Image/Image.js
+++ b/src/containers/PageBuilder/Primitives/Image/Image.js
@@ -40,7 +40,7 @@ export const FieldImage = React.forwardRef((props, ref) => {
   const firstImageVariant = variants[variantNames[0]];
   const { width: aspectWidth, height: aspectHeight } = firstImageVariant || {};
 
-  const classes = classNames(rootClassName || css.markdownImage, className);
+  const classes = classNames(rootClassName || css.fieldImage, className);
   return (
     <AspectRatioWrapper className={classes} width={aspectWidth || 1} height={aspectHeight || 1}>
       <ResponsiveImage

--- a/src/containers/PageBuilder/Primitives/Image/Image.module.css
+++ b/src/containers/PageBuilder/Primitives/Image/Image.module.css
@@ -1,5 +1,9 @@
 .markdownImage {
-  width: 100%;
+  /**
+   * Note: markdown images might be too small for filling the space.
+   */
+  width: auto;
+  max-width: 100%;
   border-radius: 8px;
   object-fit: cover;
 }


### PR DESCRIPTION
- Remove the `background-color` from images (this makes more sense for transparent images)
- Markdown images: don't stretch images. max-width => column width, but smaller images are allowed.